### PR TITLE
Generalize manual correction scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+.idea
+*/__pycache__/
+venv/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
-# manual-correction
+# Manual correction
+
+This repository contains scripts for the manual correction of spinal cord labels. Currently supported labels are: 
+- spinal cord segmentation
+- gray matter segmentation
+- disc labels
+- ponto-medullary junction (PMJ) label
+
+## Installation
+
+```console
+git clone https://github.com/spinalcordtoolbox/manual-correction.git
+cd manual-correction
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Usage
+
+> **Note** All scripts currently assume BIDS-compliant data. For more information about the BIDS standard, please visit http://bids.neuroimaging.io.
+
+### `package_for_correction.py`
+
+The `package_for_correction.py` script is used to create a zip file containing the processed images and labels 
+(segmentations, disc labels, etc.). The zip file is then sent to the user for manual correction.
+
+This is useful when you need to correct the labels of a large dataset processed on a remote server. In this case, you do
+not need to copy the whole dataset. Instead, only the images and labels that need to be corrected are zipped. The yaml 
+list of images to correct can be obtained from the [SCT QC html report](https://spinalcordtoolbox.com/overview/concepts/inspecting-results-qc-fsleyes.html#how-do-i-use-the-qc-report).
+
+### `manual_correction.py`
+
+The `manual_correction.py` script is used to correct the labels (segmentations, disc labels, etc.) of a dataset. 
+The script takes as input a processed dataset and outputs the corrected labels to `derivatives/labels` folder.
+
+For the correction of spinal cord and gray matter segmentation, you can choose a viewer ([FSLeyes](https://open.win.ox.ac.uk/pages/fsl/fsleyes/fsleyes/userdoc/#), [ITK-SNAP](http://www.itksnap.org/pmwiki/pmwiki.php), [3D Slicer](https://www.slicer.org)).
+
+For the correction of vertebral labeling and ponto-medullary junction (PMJ), [sct_label_utils](https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/master/spinalcordtoolbox/scripts/sct_label_utils.py) is used.
+
+### `copy_files_to_derivatives.py`
+
+The `copy_files_to_derivatives.py` script is used to copy manually corrected labels (segmentations, disc labels, etc.) 
+from your local `derivatives/labels` folder to the already existing git-annex BIDS dataset's `derivatives/labels` folder.

--- a/copy_files_to_derivatives.py
+++ b/copy_files_to_derivatives.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+#
+# Copy manually corrected labels (segmentations, vertebral labeling, etc.) from the preprocessed dataset to the
+# git-annex BIDS dataset's derivatives folder
+#
+# Authors: Jan Valosek
+#
+
+import argparse
+import glob
+import os
+import shutil
+import utils
+
+
+def get_parser():
+    """
+    parser function
+    """
+
+    parser = argparse.ArgumentParser(
+        description='Copy manually corrected files (segmentations, vertebral labeling, etc.) from the source '
+                    'preprocessed dataset to the git-annex BIDS derivatives folder',
+        formatter_class=utils.SmartFormatter,
+        prog=os.path.basename(__file__).strip('.py')
+    )
+    parser.add_argument(
+        '-path-in',
+        metavar="<folder>",
+        required=True,
+        type=str,
+        help='Path to the folder with manually corrected files (usually derivatives). The script assumes that labels '
+             'folder is located in the provided folder.'
+    )
+    parser.add_argument(
+        '-path-out',
+        metavar="<folder>",
+        required=True,
+        type=str,
+        help='Path to the BIDS dataset where manually corrected files will be copied. Include also derivatives folder '
+             'in the path. Files will be copied to the derivatives/label folder.'
+    )
+
+    return parser
+
+
+def main():
+
+    # Parse the command line arguments
+    parser = get_parser()
+    args = parser.parse_args()
+
+    # Check if path_in exists
+    if os.path.isdir(args.path_in):
+        path_in = os.path.join(os.path.abspath(args.path_in), 'labels')
+    else:
+        raise NotADirectoryError(f'{args.path_in} does not exist.')
+
+    # Check if path_out exists
+    if os.path.isdir(args.path_out):
+        path_out = os.path.join(os.path.abspath(args.path_out), 'labels')
+    else:
+        raise NotADirectoryError(f'{args.path_out} does not exist.')
+
+    # Loop across files in input dataset
+    for path_file_in in sorted(glob.glob(path_in + '/**/*.nii.gz', recursive=True)):
+        sub, ses, filename, contrast = utils.fetch_subject_and_session(path_file_in)
+        # Construct path for the output file
+        path_file_out = os.path.join(path_out, sub, ses, contrast, filename)
+        # Check if subject's folder exists in the output dataset, if not, create it
+        path_subject_folder_out = os.path.join(path_out, sub, ses, contrast)
+        if not os.path.isdir(path_subject_folder_out):
+            os.makedirs(path_subject_folder_out)
+            print(f'Creating directory: {path_subject_folder_out}')
+        # Copy nii and json files to the output dataset
+        # TODO - consider rsync instead of shutil.copy
+        shutil.copy(path_file_in, path_file_out)
+        print(f'Copying: {path_file_in} to {path_file_out}')
+        path_file_json_in = path_file_in.replace('nii.gz', 'json')
+        path_file_json_out = path_file_out.replace('nii.gz', 'json')
+        shutil.copy(path_file_json_in, path_file_json_out)
+        print(f'Copying: {path_file_json_in} to {path_file_json_out}')
+
+
+if __name__ == '__main__':
+    main()

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -357,6 +357,8 @@ def main():
         if args.add_seg_only and task == 'FILES_SEG':
             # Remove the files in the -config list
             for file in files:
+                # Remove the file suffix (e.g., '_RPI_r') to match the list of files in -path-in
+                file = utils.remove_suffix(file, args.suffix_files_in)
                 if file in file_list:
                     file_list.remove(file)
             files = file_list  # Rename to use those files instead of the ones to exclude

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -253,6 +253,34 @@ def create_json(fname_nifti, name_rater):
     fname_json = fname_nifti.rstrip('.nii').rstrip('.nii.gz') + '.json'
     with open(fname_json, 'w') as outfile:
         json.dump(metadata, outfile, indent=4)
+        # Add last newline
+        outfile.write("\n")
+
+
+def ask_if_modify(fname_label):
+    """
+    Check if file under derivatives already exists. If so, asks user if they want to modify it.
+    :param fname_label:
+    :return:
+    """
+    if os.path.isfile(fname_label):
+        answer = None
+        while answer not in ("y", "n"):
+            answer = input("WARNING! The file {} already exists. "
+                           "Would you like to modify it? [y/n] ".format(fname_label))
+            if answer == "y":
+                do_labeling = True
+                overwrite = False
+            elif answer == "n":
+                do_labeling = False
+                overwrite = False
+            else:
+                print("Please answer with 'y' or 'n'")
+    else:
+        do_labeling = True
+        overwrite = True
+
+    return do_labeling, overwrite
 
 
 def main():

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -5,7 +5,7 @@
 #
 # For usage, type: python manual_correction.py -h
 #
-# Authors: Jan Valosek, Sandrine Bédard, Julien Cohen-Adad
+# Authors: Jan Valosek, Sandrine Bédard, Naga Karthik, Julien Cohen-Adad
 #
 
 import argparse

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -228,16 +228,18 @@ def correct_vertebral_labeling(fname, fname_label, label_list, viewer='sct_label
         viewer_not_found(viewer)
 
 
-def correct_pmj_label(fname, fname_label):
+def correct_pmj_label(fname, fname_label, viewer='sct_label_utils'):
     """
     Open sct_label_utils to manually label PMJ.
     :param fname:
     :param fname_label:
-    :param name_rater:
     :return:
     """
-    message = "Click at the posterior tip of the pontomedullary junction (PMJ) then click 'Save and Quit'."
-    os.system('sct_label_utils -i {} -create-viewer 50 -o {} -msg "{}"'.format(fname, fname_label, message))
+    if shutil.which(viewer) is not None:  # Check if command 'sct_label_utils' exists
+        message = "Click at the posterior tip of the pontomedullary junction (PMJ). Then click 'Save and Quit'."
+        os.system('sct_label_utils -i {} -create-viewer 50 -o {} -msg "{}"'.format(fname, fname_label, message))
+    else:
+        viewer_not_found(viewer)
 
 
 def create_json(fname_nifti, name_rater):

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -304,6 +304,14 @@ def main():
     # check for missing files before starting the whole process
     utils.check_files_exist(dict_yml, args.path_in)
 
+    suffix_dict = {
+        'FILES_SEG': args.suffix_files_seg,         # e.g., _seg or _label-SC_mask
+        'FILES_GMSEG': args.suffix_files_gmseg,     # e.g., _gmseg or _label-GM_mask
+        'FILES_LABEL': args.suffix_files_label,     # e.g., _labels or _labels-disc
+        'FILES_PMJ': '_pmj'
+    }
+
+    path_out = utils.get_full_path(args.path_out)
     # check that output folder exists and has write permission
     path_out_deriv = utils.check_output_folder(args.path_out, FOLDER_DERIVATIVES)
 

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -325,9 +325,10 @@ def main():
 
     # Get list of segmentations files for all subjects in -path-in (if -add-seg-only)
     if args.add_seg_only:
-        path_list = glob.glob(args.path_in + "/**/*_seg.nii.gz", recursive=True)  # TODO: add other extension
+        path_list = glob.glob(args.path_in + "/**/*" + args.suffix_files_seg + ".nii.gz", recursive=True)
         # Get only filenames without suffix _seg  to match files in -config .yml list
-        file_list = [utils.remove_suffix(os.path.split(path)[-1], '_seg') for path in path_list]
+        # TODO: check if the line below is robust enough
+        file_list = [utils.remove_suffix(os.path.split(path)[-1], args.suffix_files_seg) for path in path_list]
 
     # TODO: address "none" issue if no file present under a key
     # Perform manual corrections

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -144,9 +144,17 @@ def get_parser():
     return parser
 
 
-def get_function(task):
+# TODO: add also sct_get_centerline
+def get_function_for_qc(task):
+    """
+    Get the function to use for QC based on the task.
+    :param task:
+    :return:
+    """
     if task == 'FILES_SEG':
         return 'sct_deepseg_sc'
+    elif task == "FILES_GMSEG":
+        return "sct_deepseg_gm"
     elif task == 'FILES_LABEL':
         return 'sct_label_utils'
     elif task == 'FILES_PMJ':

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -415,10 +415,16 @@ def main():
                             correct_pmj_label(fname, fname_label)
                         else:
                             sys.exit('Task not recognized from yml file: {}'.format(task))
-                        # create json sidecar with the name of the expert rater
-                        create_json(fname_label, name_rater)
-                        # Generate QC report
-                        generate_qc(fname, fname_label, task, fname_qc, subject, args.config)
+                        
+                        if task == 'FILES_LESION':
+                            # create json sidecar with the name of the expert rater
+                            create_json(fname_label, name_rater)
+                            # NOTE: QC for lesion segmentation does not exist or not implemented yet
+                        else:
+                            # create json sidecar with the name of the expert rater
+                            create_json(fname_label, name_rater)
+                            # Generate QC report
+                            generate_qc(fname, fname_label, task, fname_qc, subject, args.config)
 
                 # Generate QC report only
                 if args.qc_only:

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -25,8 +25,8 @@ def get_parser():
     parser function
     """
     parser = argparse.ArgumentParser(
-        description='Manual correction of spinal cord segmentation, gray matter segmentation, vertebral labeling, and '
-                    'pontomedullary junction labeling.'
+        description='Manual correction of spinal cord segmentation, gray matter segmentation, multiple sclerosis '
+                    'lesion segmentation, vertebral labeling, and pontomedullary junction labeling. '
                     'Manually corrected files are saved under derivatives/ folder (according to BIDS standard).',
         formatter_class=utils.SmartFormatter,
         prog=os.path.basename(__file__).strip('.py')
@@ -37,10 +37,12 @@ def get_parser():
         required=True,
         help=
         "R|Config yaml file listing images that require manual corrections for segmentation and vertebral "
-        "labeling. 'FILES_SEG' lists images associated with spinal cord segmentation "
-        ",'FILES_GMSEG' lists images associated with gray matter segmentation "
-        ",'FILES_LABEL' lists images associated with vertebral labeling "
-        "and 'FILES_PMJ' lists images associated with pontomedullary junction labeling"
+        "labeling. "
+        "'FILES_SEG' lists images associated with spinal cord segmentation, "
+        "'FILES_GMSEG' lists images associated with gray matter segmentation, "
+        "'FILES_LESION' lists images associated with multiple sclerosis lesion segmentation, "
+        "'FILES_LABEL' lists images associated with vertebral labeling, "
+        "and 'FILES_PMJ' lists images associated with pontomedullary junction labeling. "
         "You can validate your .yml file at this website: http://www.yamllint.com/."
         "Below is an example .yml file:\n"
         + dedent(
@@ -49,6 +51,9 @@ def get_parser():
             - sub-001_T1w.nii.gz
             - sub-002_T2w.nii.gz
             FILES_GMSEG:
+            - sub-001_T1w.nii.gz
+            - sub-002_T2w.nii.gz
+            FILES_LESION:
             - sub-001_T1w.nii.gz
             - sub-002_T2w.nii.gz
             FILES_LABEL:

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -347,7 +347,6 @@ def main():
     if args.add_seg_only:
         path_list = glob.glob(args.path_in + "/**/*" + args.suffix_files_seg + ".nii.gz", recursive=True)
         # Get only filenames without suffix _seg  to match files in -config .yml list
-        # TODO: check if the line below is robust enough
         file_list = [utils.remove_suffix(os.path.split(path)[-1], args.suffix_files_seg) for path in path_list]
 
     # TODO: address "none" issue if no file present under a key

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -163,37 +163,51 @@ def get_function_for_qc(task):
         raise ValueError("This task is not recognized: {}".format(task))
 
 
-def get_suffix(task, suffix=''):
-    if task == 'FILES_SEG':
-        return '_seg'+suffix
-    elif task == 'FILES_LABEL':
-        return '_labels'+suffix
-    elif task == 'FILES_PMJ':
-        return '_pmj'+suffix
-
-    else:
-        raise ValueError("This task is not recognized: {}".format(task))
-
-
-def correct_segmentation(fname, fname_seg_out):
+def correct_segmentation(fname, fname_seg_out, viewer):
     """
-    Copy fname_seg in fname_seg_out, then open ITK-SNAP with fname and fname_seg_out.
+    Open viewer (ITK-SNAP, FSLeyes, or 3D Slicer) with fname and fname_seg_out.
     :param fname:
-    :param fname_seg:
     :param fname_seg_out:
-    :param name_rater:
+    :param viewer:
     :return:
     """
     # launch ITK-SNAP
-    # Note: command line differs for macOs/Linux and Windows
-    print("In ITK-SNAP, correct the segmentation, then save it with the same name (overwrite).")
-    if shutil.which('itksnap') is not None:  # Check if command 'itksnap' exists
-        os.system('itksnap -g ' + fname + ' -s ' + fname_seg_out)  # for macOS and Linux
-    elif shutil.which('ITK-SNAP') is not None:  # Check if command 'ITK-SNAP' exists
-        os.system('ITK-SNAP -g ' + fname + ' -s ' + fname_seg_out)  # For windows
-    else:
-        sys.exit("ITK-SNAP not found. Please install it before using this program or check if it was added to PATH variable. Exit program.")
+    if viewer == 'itksnap':
+        print("In ITK-SNAP, correct the segmentation, then save it with the same name (overwrite).")
+        # Note: command line differs for macOs/Linux and Windows
+        if shutil.which('itksnap') is not None:  # Check if command 'itksnap' exists
+            # macOS and Linux
+            os.system('itksnap -g {} -s {}'.format(fname, fname_seg_out))
+        elif shutil.which('ITK-SNAP') is not None:  # Check if command 'ITK-SNAP' exists
+            # Windows
+            os.system('ITK-SNAP -g {} -s {}'.format(fname, fname_seg_out))
+        else:
+            viewer_not_found(viewer)
+    # launch FSLeyes
+    elif viewer == 'fsleyes':
+        if shutil.which('fsleyes') is not None:  # Check if command 'fsleyes' exists
+            print("In FSLeyes, click on 'Edit mode', correct the segmentation, and then save it with the same name "
+                  "(overwrite).")
+            os.system('fsleyes {} {} -cm red'.format(fname, fname_seg_out))
+        else:
+            viewer_not_found(viewer)
+    # launch 3D Slicer
+    elif viewer == 'slicer':
+        if shutil.which('slicer') is not None:
+            # TODO: Add instructions for 3D Slicer
+            pass
+        else:
+            viewer_not_found(viewer)
 
+
+def viewer_not_found(viewer):
+    """
+    Print that viewer is not installed and exit the program.
+    :param viewer:
+    :return:
+    """
+    sys.exit("{} not found. Please install it before using this program or check if it was added to PATH variable. "
+             "You can also use another viewer by using the flag -viewer.".format(viewer))
 
 def correct_vertebral_labeling(fname, fname_label):
     """

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -266,9 +266,10 @@ def create_json(fname_nifti, name_rater):
 def ask_if_modify(fname_label):
     """
     Check if file under derivatives already exists. If so, asks user if they want to modify it.
-    :param fname_label:
+    :param fname_label: file under derivatives
     :return:
     """
+    # Check if file under derivatives already exists
     if os.path.isfile(fname_label):
         answer = None
         while answer not in ("y", "n"):

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -276,17 +276,18 @@ def ask_if_modify(fname_label):
                            "Would you like to modify it? [y/n] ".format(fname_label))
             if answer == "y":
                 do_labeling = True
-                overwrite = False
             elif answer == "n":
                 do_labeling = False
-                overwrite = False
             else:
                 print("Please answer with 'y' or 'n'")
+            # We don't want to copy because we want to modify the existing file
+            copy = False
+    # If the file under derivatives does not exist, copy it from processed data
     else:
         do_labeling = True
-        overwrite = True
+        copy = True
 
-    return do_labeling, overwrite
+    return do_labeling, copy
 
 
 def generate_qc(fname, fname_label, task, fname_qc, subject, config_file):
@@ -388,10 +389,10 @@ def main():
                 os.makedirs(os.path.join(path_out_deriv, subject, ses, contrast), exist_ok=True)
                 if not args.qc_only:
                     # Check if file under derivatives already exists. If so, asks user if they want to modify it.
-                    do_labeling, overwrite = ask_if_modify(fname_label)
+                    do_labeling, copy = ask_if_modify(fname_label)
                     # Perform labeling (i.e., segmentation correction, labeling correction etc.) for the specific task
                     if do_labeling:
-                        if overwrite:
+                        if copy:
                             # Copy file to derivatives folder
                             shutil.copyfile(fname_seg, fname_label)
                             print(f'Copying: {fname_seg} to {fname_label}')

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -130,6 +130,13 @@ def get_parser():
         default='itksnap'
     )
     parser.add_argument(
+        '-fsl-color',
+        help="Color to be used for loading the label file on FSLeyes (default: red). `fsleyes -h` gives all the available color options. " 
+             "If using a combination of colors, specify them with '-'. E.g. red-yellow ",
+        type=str,
+        default='red'
+    )
+    parser.add_argument(
         '-qc-only',
         help="Only output QC report based on the manually-corrected files already present in the derivatives folder. "
              "Skip the copy of the source files, and the opening of the manual correction pop-up windows.",
@@ -169,7 +176,7 @@ def get_function_for_qc(task):
         raise ValueError("This task is not recognized: {}".format(task))
 
 
-def correct_segmentation(fname, fname_seg_out, viewer):
+def correct_segmentation(fname, fname_seg_out, viewer, viewer_color):
     """
     Open viewer (ITK-SNAP, FSLeyes, or 3D Slicer) with fname and fname_seg_out.
     :param fname:
@@ -194,7 +201,7 @@ def correct_segmentation(fname, fname_seg_out, viewer):
         if shutil.which('fsleyes') is not None:  # Check if command 'fsleyes' exists
             print("In FSLeyes, click on 'Edit mode', correct the segmentation, and then save it with the same name "
                   "(overwrite).")
-            os.system('fsleyes {} {} -cm red'.format(fname, fname_seg_out))
+            os.system('fsleyes {} {} -cm {}'.format(fname, fname_seg_out, viewer_color))
         else:
             viewer_not_found(viewer)
     # launch 3D Slicer
@@ -399,9 +406,9 @@ def main():
                             print(f'Copying: {fname_seg} to {fname_label}')
                         if task in ['FILES_SEG', 'FILES_GMSEG']:
                             if not args.add_seg_only:
-                                correct_segmentation(fname, fname_label, args.viewer)
+                                correct_segmentation(fname, fname_label, args.viewer, args.fsl_color)
                         elif task == 'FILES_LESION':
-                            correct_segmentation(fname, fname_label, args.viewer)
+                            correct_segmentation(fname, fname_label, args.viewer, args.fsl_color)
                         elif task == 'FILES_LABEL':
                             correct_vertebral_labeling(fname, fname_label, args.label_list)
                         elif task == 'FILES_PMJ':

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -283,6 +283,24 @@ def ask_if_modify(fname_label):
     return do_labeling, overwrite
 
 
+def generate_qc(fname, fname_label, task, fname_qc, subject, config_file):
+    """
+    Generate QC report.
+    :param fname:
+    :param fname_seg:
+    :param fname_label:
+    :param fname_pmj:
+    :param qc_folder:
+    :return:
+    """
+    os.system('sct_qc -i {} -s {} -p {} -qc {} -qc-subject {}'.format(
+        fname, fname_label, get_function_for_qc(task), fname_qc, subject))
+    # Archive QC folder
+    shutil.copy(utils.get_full_path(config_file), fname_qc)
+    shutil.make_archive(fname_qc, 'zip', fname_qc)
+    print("Archive created:\n--> {}".format(fname_qc + '.zip'))
+
+
 def main():
 
     # Parse the command line arguments
@@ -379,15 +397,12 @@ def main():
                             sys.exit('Task not recognized from yml file: {}'.format(task))
                         # create json sidecar with the name of the expert rater
                         create_json(fname_label, name_rater)
+                        # Generate QC report
+                        generate_qc(fname, fname_label, task, fname_qc, subject, args.config)
 
-                # generate QC report (only for vertebral labeling or for qc only)
-                if args.qc_only or task != 'FILES_SEG':
-                    os.system('sct_qc -i {} -s {} -p {} -qc {} -qc-subject {}'.format(
-                        fname, fname_label, get_function_for_qc(task), fname_qc, subject))
-                    # Archive QC folder
-                    shutil.copy(utils.get_full_path(args.config), fname_qc)
-                    shutil.make_archive(fname_qc, 'zip', fname_qc)
-                    print("Archive created:\n--> {}".format(fname_qc+'.zip'))
+                # Generate QC report only
+                if args.qc_only:
+                    generate_qc(fname, fname_label, task, fname_qc, subject, args.config)
 
 
 if __name__ == '__main__':

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -131,8 +131,8 @@ def get_parser():
     )
     parser.add_argument(
         '-fsl-color',
-        help="Color to be used for loading the label file on FSLeyes (default: red). `fsleyes -h` gives all the available color options. " 
-             "If using a combination of colors, specify them with '-'. E.g. red-yellow ",
+        help="Color to be used for loading the label file on FSLeyes (default: red). `fsleyes -h` gives all the "
+             "available color options. If using a combination of colors, specify them with '-', e.g. 'red-yellow'.",
         type=str,
         default='red'
     )
@@ -182,6 +182,7 @@ def correct_segmentation(fname, fname_seg_out, viewer, viewer_color):
     :param fname:
     :param fname_seg_out:
     :param viewer:
+    :param viewer_color: color to be used for the label. Only valid for on FSLeyes (default: red).
     :return:
     """
     # launch ITK-SNAP

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -118,6 +118,12 @@ def get_parser():
         default='_labels'
     )
     parser.add_argument(
+        '-suffix-files-pmj',
+        help="FILES-PMJ suffix. Available options: '_pmj' (default), '_label-pmj'.",
+        choices=['_pmj', '_label-pmj'],
+        default='_pmj'
+    )
+    parser.add_argument(
         '-label-list',
         help="Provide a comma-separated list containing individual values and/or intervals. Example: '1:4,6,8' or 1:20 "
              "(default)",
@@ -345,7 +351,7 @@ def main():
         'FILES_GMSEG': args.suffix_files_gmseg,     # e.g., _gmseg or _label-GM_mask
         'FILES_LESION': args.suffix_files_lesion,     # e.g., _lesion
         'FILES_LABEL': args.suffix_files_label,     # e.g., _labels or _labels-disc
-        'FILES_PMJ': '_pmj'
+        'FILES_PMJ': args.suffix_files_pmj          # e.g., _pmj or _label-pmj
     }
 
     path_out = utils.get_full_path(args.path_out)

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -295,18 +295,8 @@ def main():
     else:
         coloredlogs.install(fmt='%(message)s', level='INFO')
 
-    # check if input yml file exists
-    if os.path.isfile(args.config):
-        fname_yml = args.config
-    else:
-        sys.exit("ERROR: Input yml file {} does not exist or path is wrong.".format(args.config))
-
-    # fetch input yml file as dict
-    with open(fname_yml, 'r') as stream:
-        try:
-            dict_yml = yaml.safe_load(stream)
-        except yaml.YAMLError as exc:
-            print(exc)
+    # Fetch configuration from YAML file
+    dict_yml = utils.fetch_yaml_config(args.config)
 
     # Curate dict_yml to only have filenames instead of absolute path
     dict_yml = utils.curate_dict_yml(dict_yml)

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -321,7 +321,8 @@ def main():
     dict_yml = utils.curate_dict_yml(dict_yml)
 
     # Check for missing files before starting the whole process
-    utils.check_files_exist(dict_yml, utils.get_full_path(args.path_in))
+    if not args.add_seg_only:
+        utils.check_files_exist(dict_yml, utils.get_full_path(args.path_in))
 
     suffix_dict = {
         'FILES_SEG': args.suffix_files_seg,         # e.g., _seg or _label-SC_mask

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -209,16 +209,23 @@ def viewer_not_found(viewer):
     sys.exit("{} not found. Please install it before using this program or check if it was added to PATH variable. "
              "You can also use another viewer by using the flag -viewer.".format(viewer))
 
-def correct_vertebral_labeling(fname, fname_label):
+
+def correct_vertebral_labeling(fname, fname_label, label_list, viewer='sct_label_utils'):
     """
     Open sct_label_utils to manually label vertebral levels.
     :param fname:
     :param fname_label:
-    :param name_rater:
+    :param label_list: Comma-separated list containing individual values and/or intervals. Example: '1:4,6,8' or 1:20
     :return:
     """
-    message = "Click at the posterior tip of the disc between C1-C2, C2-C3 and C3-C4 vertebral levels, then click 'Save and Quit'."
-    os.system('sct_label_utils -i {} -create-viewer 2,3,4 -o {} -msg "{}"'.format(fname, fname_label, message))
+    if shutil.which(viewer) is not None:  # Check if command 'sct_label_utils' exists
+        message = "Click at the posterior tip of the disc(s). Then click 'Save and Quit'."
+        if os.path.exists(fname_label):
+            os.system('sct_label_utils -i {} -create-viewer {} -o {} -ilabel {} -msg "{}"'.format(fname, label_list, fname_label, fname_label, message))
+        else:
+            os.system('sct_label_utils -i {} -create-viewer {} -o {} -msg "{}"'.format(fname, label_list, fname_label, message))
+    else:
+        viewer_not_found(viewer)
 
 
 def correct_pmj_label(fname, fname_label):

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -290,6 +290,7 @@ def main():
     args = parser.parse_args()
 
     # Logging level
+    # TODO: how is this actually used?
     if args.verbose:
         coloredlogs.install(fmt='%(message)s', level='DEBUG')
     else:
@@ -333,7 +334,8 @@ def main():
     # TODO: address "none" issue if no file present under a key
     # Perform manual corrections
     for task, files in dict_yml.items():
-        # Get the list of segmentation files to add to derivatives, excluding the manually corrrected files in -config.
+        # Get the list of segmentation files to add to derivatives, excluding the manually corrected files in -config.
+        # TODO: probably extend also for other tasks (such as FILES_GMSEG)
         if args.add_seg_only and task == 'FILES_SEG':
             # Remove the files in the -config list
             for file in files:

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -75,6 +75,55 @@ def get_parser():
         default='./'
     )
     parser.add_argument(
+        '-path-derivatives',
+        metavar="<folder>",
+        help=
+        "R|Path to the 'derivatives' BIDS-complaint folder where the corrected labels will be saved. "
+        "Example: derivatives/labels"
+        "Note: if the provided folder (e.g., 'derivatives/labels') does not already exist, it will be created."
+        "Note: if segmentation or labels files already exist and you would like to correct them, provide path to them "
+        "within this flag.",
+        default=os.path.join('derivatives', 'labels')
+    )
+    parser.add_argument(
+        '-suffix-files-in',
+        help=
+        "R|Suffix of the input files. For example: '_RPI_r'."
+        "Note: this flag is useful in cases when the input files have been processed and thus contains a specific "
+        "suffix.",
+        default=''
+    )
+    parser.add_argument(
+        '-suffix-files-seg',
+        help="FILES-SEG suffix. Available options: '_seg' (default), '_label-SC_mask'.",
+        choices=['_seg', '_label-SC_mask'],
+        default='_seg'
+    )
+    parser.add_argument(
+        '-suffix-files-gmseg',
+        help="FILES-GMSEG suffix. Available options: '_gmseg' (default), '_label-GM_mask'.",
+        choices=['_gmseg', '_label-GM_mask'],
+        default='_gmseg'
+    )
+    parser.add_argument(
+        '-suffix-files-label',
+        help="FILES-LABEL suffix. Available options: '_labels' (default), '_labels-disc'.",
+        choices=['_labels', '_labels-disc'],
+        default='_labels'
+    )
+    parser.add_argument(
+        '-label-list',
+        help="Provide a comma-separated list containing individual values and/or intervals. Example: '1:4,6,8' or 1:20 "
+             "(default)",
+        default='1:20'
+    )
+    parser.add_argument(
+        '-viewer',
+        help="Viewer used for manual correction. Available options: 'itksnap' (default), 'fsleyes', 'slicer'.",
+        choices=['fsleyes', 'itksnap', 'slicer'],
+        default='itksnap'
+    )
+    parser.add_argument(
         '-qc-only',
         help="Only output QC report based on the manually-corrected files already present in the derivatives folder. "
              "Skip the copy of the source files, and the opening of the manual correction pop-up windows.",

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -79,7 +79,7 @@ def get_parser():
         metavar="<folder>",
         help=
         "R|Path to the 'derivatives' BIDS-complaint folder where the corrected labels will be saved. "
-        "Example: derivatives/labels"
+        "Default: derivatives/labels"
         "Note: if the provided folder (e.g., 'derivatives/labels') does not already exist, it will be created."
         "Note: if segmentation or labels files already exist and you would like to correct them, provide path to them "
         "within this flag.",

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -106,6 +106,12 @@ def get_parser():
         default='_gmseg'
     )
     parser.add_argument(
+        '-suffix-files-lesion',
+        help="FILES-LESION suffix. Available options: '_lesion' (default).",
+        choices=['_lesion'],
+        default='_lesion'
+    )
+    parser.add_argument(
         '-suffix-files-label',
         help="FILES-LABEL suffix. Available options: '_labels' (default), '_labels-disc'.",
         choices=['_labels', '_labels-disc'],
@@ -327,6 +333,7 @@ def main():
     suffix_dict = {
         'FILES_SEG': args.suffix_files_seg,         # e.g., _seg or _label-SC_mask
         'FILES_GMSEG': args.suffix_files_gmseg,     # e.g., _gmseg or _label-GM_mask
+        'FILES_LESION': args.suffix_files_lesion,     # e.g., _lesion
         'FILES_LABEL': args.suffix_files_label,     # e.g., _labels or _labels-disc
         'FILES_PMJ': '_pmj'
     }
@@ -391,6 +398,8 @@ def main():
                         if task in ['FILES_SEG', 'FILES_GMSEG']:
                             if not args.add_seg_only:
                                 correct_segmentation(fname, fname_label, args.viewer)
+                        elif task == 'FILES_LESION':
+                            correct_segmentation(fname, fname_label, args.viewer)
                         elif task == 'FILES_LABEL':
                             correct_vertebral_labeling(fname, fname_label, args.label_list)
                         elif task == 'FILES_PMJ':
@@ -404,7 +413,9 @@ def main():
 
                 # Generate QC report only
                 if args.qc_only:
-                    generate_qc(fname, fname_label, task, fname_qc, subject, args.config)
+                    # Note: QC for lesion segmentation is not implemented yet
+                    if task != "FILES_LESION":
+                        generate_qc(fname, fname_label, task, fname_qc, subject, args.config)
 
 
 if __name__ == '__main__':

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -129,9 +129,9 @@ def get_parser():
         default='_pmj'
     )
     parser.add_argument(
-        '-label-list',
-        help="Provide a comma-separated list containing individual values and/or intervals. Example: '1:4,6,8' or 1:20 "
-             "(default)",
+        '-label-disc-list',
+        help="Comma-separated list containing individual values and/or intervals for disc labeling. Example: '1:4,6,8' "
+             "or 1:20 (default)",
         default='1:20'
     )
     parser.add_argument(
@@ -422,7 +422,7 @@ def main():
                         elif task == 'FILES_LESION':
                             correct_segmentation(fname, fname_label, args.viewer, args.fsl_color)
                         elif task == 'FILES_LABEL':
-                            correct_vertebral_labeling(fname, fname_label, args.label_list)
+                            correct_vertebral_labeling(fname, fname_label, args.label_disc_list)
                         elif task == 'FILES_PMJ':
                             correct_pmj_label(fname, fname_label)
                         else:

--- a/package_for_correction.py
+++ b/package_for_correction.py
@@ -82,6 +82,12 @@ def get_parser():
         default='_gmseg'
     )
     parser.add_argument(
+        '-suffix-files-lesion',
+        help="FILES-LESION suffix. Available options: '_lesion' (default).",
+        choices=['_lesion'],
+        default='_lesion'
+    )
+    parser.add_argument(
         '-suffix-files-label',
         help="FILES-LABEL suffix. Available options: '_labels' (default), '_labels-disc'.",
         choices=['_labels', '_labels-disc'],
@@ -133,6 +139,7 @@ def main():
     suffix_dict = {
         'FILES_SEG': args.suffix_files_seg,         # e.g., _seg or _label-SC_mask
         'FILES_GMSEG': args.suffix_files_gmseg,     # e.g., _gmseg or _label-GM_mask
+        'FILES_LESION': args.suffix_files_lesion,   # e.g., _lesion
         'FILES_LABEL': args.suffix_files_label,     # e.g., _labels or _labels-disc
         'FILES_PMJ': args.suffix_files_pmj          # e.g., _pmj or _label-pmj
     }

--- a/package_for_correction.py
+++ b/package_for_correction.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 #
-# Script to package data for manual correction from SpineGeneric adapted for ukbiobank cord CSA project.
+# Script to package data for manual correction from SpineGeneric adapted for canproco project.
 #
 # For usage, type: python package_for_correction.py -h
 #
-# Author: Julien Cohen-Adad
+# Authors: Jan Valosek, Sandrine Bédard, Julien Cohen-Adad
+#
 
 
 import os
@@ -13,10 +14,8 @@ import shutil
 import tempfile
 from textwrap import dedent
 import argparse
-import yaml
 import coloredlogs
-
-import pipeline_ukbiobank.utils as utils
+import utils
 
 
 def get_parser():
@@ -35,26 +34,34 @@ def get_parser():
         metavar="<file>",
         required=True,
         help=
-        "R|Config .yml file listing images that require manual corrections for segmentation and vertebral "
-        "labeling. 'FILES_SEG' lists images associated with spinal cord segmentation,"
-        "and 'FILES_LABEL' lists images associated with vertebral labeling. "
-        "You can validate your .yml file at this website: http://www.yamllint.com/. Below is an example .yml file:\n"
+        "R|Config yaml file listing images that require manual corrections for segmentation and vertebral "
+        "labeling. 'FILES_SEG' lists images associated with spinal cord segmentation "
+        ",'FILES_GMSEG' lists images associated with gray matter segmentation "
+        ",'FILES_LABEL' lists images associated with vertebral labeling "
+        "and 'FILES_PMJ' lists images associated with pontomedullary junction labeling"
+        "You can validate your .yml file at this website: http://www.yamllint.com/."
+        "Below is an example .yml file:\n"
         + dedent(
             """
             FILES_SEG:
-            - sub-1000032_T1w.nii.gz
-            - sub-1000083_T2w.nii.gz
+            - sub-001_T1w.nii.gz
+            - sub-002_T2w.nii.gz
+            FILES_GMSEG:
+            - sub-001_T1w.nii.gz
+            - sub-002_T2w.nii.gz
             FILES_LABEL:
-            - sub-1000032_T1w.nii.gz
-            - sub-1000710_T1w.nii.gz\n
+            - sub-001_T1w.nii.gz
+            - sub-002_T1w.nii.gz
+            FILES_PMJ:
+            - sub-001_T1w.nii.gz
+            - sub-002_T1w.nii.gz\n
             """)
     )
     parser.add_argument(
         '-path-in',
         metavar="<folder>",
         required=True,
-        help='Path to the processed data. Example: ~/ukbiobank_results/data_processed',
-        default='./'
+        help='Path to the processed data. Example: ~/<your_dataset>/data_processed',
     )
     parser.add_argument(
         '-o',

--- a/package_for_correction.py
+++ b/package_for_correction.py
@@ -97,19 +97,9 @@ def main():
     else:
         coloredlogs.install(fmt='%(message)s', level='INFO')
 
-    # Check if input yml file exists
-    if os.path.isfile(args.config):
-        fname_yml = args.config
-    else:
-        sys.exit("ERROR: Input yml file {} does not exist or path is wrong.".format(args.config))
+    # Fetch configuration from YAML file
+    dict_yml = utils.fetch_yaml_config(args.config)
 
-    # Fetch input yml file as dict
-    with open(fname_yml, 'r') as stream:
-        try:
-            dict_yml = yaml.safe_load(stream)
-        except yaml.YAMLError as exc:
-            print(exc)
-    
     # Curate dict_yml to only have filenames instead of absolute path
     dict_yml = utils.curate_dict_yml(dict_yml)
 

--- a/package_for_correction.py
+++ b/package_for_correction.py
@@ -101,7 +101,7 @@ def copy_file(fname_in, path_out):
     os.makedirs(path_out, exist_ok=True)
     # copy file
     fname_out = shutil.copy(fname_in, path_out)
-    print("-> {}".format(fname_out))
+    print(f'Copying: {fname_in} to {fname_out}')
 
 
 def main():

--- a/package_for_correction.py
+++ b/package_for_correction.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Script to package data for manual correction from SpineGeneric adapted for canproco project.
+# Script to package data for manual correction.
 #
 # For usage, type: python package_for_correction.py -h
 #

--- a/package_for_correction.py
+++ b/package_for_correction.py
@@ -88,6 +88,12 @@ def get_parser():
         default='_labels'
     )
     parser.add_argument(
+        '-suffix-files-pmj',
+        help="FILES-PMJ suffix. Available options: '_pmj' (default), '_label-pmj'.",
+        choices=['_pmj', '_label-pmj'],
+        default='_pmj'
+    )
+    parser.add_argument(
         '-v', '--verbose',
         help="Full verbose (for debugging)",
         action='store_true'
@@ -128,7 +134,7 @@ def main():
         'FILES_SEG': args.suffix_files_seg,         # e.g., _seg or _label-SC_mask
         'FILES_GMSEG': args.suffix_files_gmseg,     # e.g., _gmseg or _label-GM_mask
         'FILES_LABEL': args.suffix_files_label,     # e.g., _labels or _labels-disc
-        'FILES_PMJ': '_pmj'
+        'FILES_PMJ': args.suffix_files_pmj          # e.g., _pmj or _label-pmj
     }
 
     # Create temp folder

--- a/package_for_correction.py
+++ b/package_for_correction.py
@@ -70,6 +70,24 @@ def get_parser():
         default='data_to_correct'
     )
     parser.add_argument(
+        '-suffix-files-seg',
+        help="FILES-SEG suffix. Available options: '_seg' (default), '_label-SC_mask'.",
+        choices=['_seg', '_label-SC_mask'],
+        default='_seg'
+    )
+    parser.add_argument(
+        '-suffix-files-gmseg',
+        help="FILES-GMSEG suffix. Available options: '_gmseg' (default), '_label-GM_mask'.",
+        choices=['_gmseg', '_label-GM_mask'],
+        default='_gmseg'
+    )
+    parser.add_argument(
+        '-suffix-files-label',
+        help="FILES-LABEL suffix. Available options: '_labels' (default), '_labels-disc'.",
+        choices=['_labels', '_labels-disc'],
+        default='_labels'
+    )
+    parser.add_argument(
         '-v', '--verbose',
         help="Full verbose (for debugging)",
         action='store_true'
@@ -104,7 +122,14 @@ def main():
     dict_yml = utils.curate_dict_yml(dict_yml)
 
     # Check for missing files before starting the whole process
-    utils.check_files_exist(dict_yml, args.path_in)
+    utils.check_files_exist(dict_yml, utils.get_full_path(args.path_in))
+
+    suffix_dict = {
+        'FILES_SEG': args.suffix_files_seg,         # e.g., _seg or _label-SC_mask
+        'FILES_GMSEG': args.suffix_files_gmseg,     # e.g., _gmseg or _label-GM_mask
+        'FILES_LABEL': args.suffix_files_label,     # e.g., _labels or _labels-disc
+        'FILES_PMJ': '_pmj'
+    }
 
     # Create temp folder
     path_tmp = tempfile.mkdtemp()
@@ -113,12 +138,8 @@ def main():
     # Note: in case the file is listed twice, we just overwrite it in the destination dir.
     for task, files in dict_yml.items():
         for file in files:
-            if task == 'FILES_SEG':
-                suffix_label = '_seg'
-            elif task == 'FILES_LABEL':
-                suffix_label = None
-            elif task == 'FILES_PMJ':
-                suffix_label = None
+            if task in suffix_dict.keys():
+                suffix_label = suffix_dict[task]
             else:
                 sys.exit('Task not recognized from yml file: {}'.format(task))
             # Copy image

--- a/package_for_correction.py
+++ b/package_for_correction.py
@@ -142,14 +142,20 @@ def main():
                 suffix_label = suffix_dict[task]
             else:
                 sys.exit('Task not recognized from yml file: {}'.format(task))
+            subject, ses, filename, contrast = utils.fetch_subject_and_session(file)
+            # Construct absolute path to the input file
+            # For example: '/Users/user/dataset/data_processed/sub-001/anat/sub-001_T2w.nii.gz'
+            fname = os.path.join(utils.get_full_path(args.path_in), subject, ses, contrast, filename)
+            # Construct absolute path to the temp folder
+            path_out = os.path.join(path_tmp, subject, ses, contrast)
             # Copy image
-            copy_file(os.path.join(args.path_in, utils.get_subject(file), utils.get_contrast(file), file),
-                      os.path.join(path_tmp, utils.get_subject(file), utils.get_contrast(file)))
+            copy_file(fname, path_out)
             # Copy label if exists
             if suffix_label is not None:
-                copy_file(os.path.join(args.path_in, utils.get_subject(file), utils.get_contrast(file),
-                                       utils.add_suffix(file, suffix_label)),
-                          os.path.join(path_tmp, utils.get_subject(file), utils.get_contrast(file)))
+                # Construct absolute path to the input label (segmentation, labeling etc.) file
+                # For example: '/Users/user/dataset/data_processed/sub-001/anat/sub-001_T2w_seg.nii.gz'
+                fname_seg = utils.add_suffix(fname, suffix_dict[task])
+                copy_file(fname_seg, path_out)
 
     # Package to zip file
     print("Creating archive...")
@@ -159,7 +165,7 @@ def main():
     if os.path.isdir(new_path_tmp):
         shutil.rmtree(new_path_tmp)
     shutil.move(path_tmp, new_path_tmp)
-    fname_archive = shutil.make_archive(args.o, 'zip', root_dir_tmp, base_dir_name)
+    fname_archive = shutil.make_archive(utils.get_full_path(args.o), 'zip', root_dir_tmp, base_dir_name)
     print("-> {}".format(fname_archive))
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+coloredlogs==15.0.1
+humanfriendly==10.0
+PyYAML==6.0

--- a/utils.py
+++ b/utils.py
@@ -1,16 +1,21 @@
 #!/usr/bin/env python
 # -*- coding: utf-8
+#
 # Collection of useful functions from spine_generic, used for manual segmentation
+#
+# Authors: Jan Valosek, Sandrine Bédard, Julien Cohen-Adad
+#
 
 import os
 import re
 import logging
+import sys
 import textwrap
 import argparse
 import subprocess
 import shutil
-from pathlib import Path
-from enum import Enum
+import yaml
+
 
 # BIDS utility tool
 def get_subject(file):

--- a/utils.py
+++ b/utils.py
@@ -141,6 +141,29 @@ def remove_suffix(fname, suffix):
     return os.path.join(stem.replace(suffix, '') + ext)
 
 
+def fetch_yaml_config(config_file):
+    """
+    Fetch configuration from YAML file
+    :param config_file: YAML file
+    :return: dictionary with configuration
+    """
+    config_file = get_full_path(config_file)
+    # Check if input yml file exists
+    if os.path.isfile(config_file):
+        fname_yml = config_file
+    else:
+        sys.exit("ERROR: Input yml file {} does not exist or path is wrong.".format(config_file))
+
+    # Fetch input yml file as dict
+    with open(fname_yml, 'r') as stream:
+        try:
+            dict_yml = yaml.safe_load(stream)
+        except yaml.YAMLError as exc:
+            print(exc)
+
+    return dict_yml
+
+
 def curate_dict_yml(dict_yml):
     """
     Curate dict_yml to only have filenames instead of absolute path

--- a/utils.py
+++ b/utils.py
@@ -203,7 +203,8 @@ def check_files_exist(dict_files, path_data):
     for task, files in dict_files.items():
         if files is not None:
             for file in files:
-                fname = os.path.join(path_data, get_subject(file), get_contrast(file), file)
+                subject, ses, filename, contrast = fetch_subject_and_session(file)
+                fname = os.path.join(path_data, subject, ses, contrast, filename)
                 if not os.path.exists(fname):
                     missing_files.append(fname)
     if missing_files:

--- a/utils.py
+++ b/utils.py
@@ -176,6 +176,15 @@ def curate_dict_yml(dict_yml):
     return dict_yml_curate
 
 
+def get_full_path(path):
+    """
+    Return full path. If ~ is passed, expand it to home directory.
+    :param path: str: Input path
+    :return: str: Full path
+    """
+    return os.path.abspath(os.path.expanduser(path))
+
+
 def check_files_exist(dict_files, path_data):
     """
     Check if all files listed in the input dictionary exist

--- a/utils.py
+++ b/utils.py
@@ -18,22 +18,29 @@ import yaml
 
 
 # BIDS utility tool
-def get_subject(file):
+def fetch_subject_and_session(filename_path):
     """
-    Get subject from BIDS file name
-    :param file:
-    :return: subject
+    Get subject ID, session ID and filename from the input BIDS-compatible filename or file path
+    The function works both on absolute file path as well as filename
+    :param filename_path: input nifti filename (e.g., sub-001_ses-01_T1w.nii.gz) or file path
+    (e.g., /home/user/MRI/bids/derivatives/labels/sub-001/ses-01/anat/sub-001_ses-01_T1w.nii.gz
+    :return: subjectID: subject ID (e.g., sub-001)
+    :return: sessionID: session ID (e.g., ses-01)
+    :return: filename: nii filename (e.g., sub-001_ses-01_T1w.nii.gz)
     """
-    return file.split('_')[0]
 
+    _, filename = os.path.split(filename_path)              # Get just the filename (i.e., remove the path)
+    subject = re.search('sub-(.*?)[_/]', filename_path)
+    subjectID = subject.group(0)[:-1] if subject else ""    # [:-1] removes the last underscore or slash
+    session = re.findall(r'ses-..', filename_path)
+    sessionID = session[0] if session else ""               # Return None if there is no session
+    contrast = 'dwi' if 'dwi' in filename_path else 'anat'  # Return contrast (dwi or anat)
+    # REGEX explanation
+    # \d - digit
+    # \d? - no or one occurrence of digit
+    # *? - match the previous element as few times as possible (zero or more times)
 
-def get_contrast(file):
-    """
-    Get contrast from BIDS file name
-    :param file:
-    :return:
-    """
-    return 'dwi' if (file.split('_')[-1]).split('.')[0] == 'dwi' else 'anat'
+    return subjectID, sessionID, filename, contrast
 
 
 class SmartFormatter(argparse.HelpFormatter):

--- a/utils.py
+++ b/utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8
 #
-# Collection of useful functions from spine_generic, used for manual segmentation
+# Collection of useful functions used by other scripts
 #
 # Authors: Jan Valosek, Sandrine Bédard, Julien Cohen-Adad
 #
@@ -216,7 +216,7 @@ def check_output_folder(path_bids, folder_derivatives):
     """
     Make sure path exists, has writing permissions, and create derivatives folder if it does not exist.
     :param path_bids:
-    :return: path_bids_derivatives
+    :return: folder_derivatives:
     """
     if path_bids is None:
         logging.error("-path-out should be provided.")


### PR DESCRIPTION
## Description

This PR proposes an initial version of scripts for manual correction workflow. For details, see [README](https://github.com/spinalcordtoolbox/manual-correction/blob/jv/generalize_manual_correction_scripts/README.md).
The scripts are based on [ukbiobank-spinalcord-csa](https://github.com/sct-pipeline/ukbiobank-spinalcord-csa) scripts. To allow easy tracking of changes proposed in this PR, I pushed the `ukbiobank-spinalcord-csa` scripts to the [main branch](https://github.com/spinalcordtoolbox/manual-correction).

Compared `ukbiobank-spinalcord-csa` scripts, I added:
- new input flags (`-path-derivatives`,  `-path-derivatives`, `-suffix-files-seg`, `-suffix-files-gmseg`, `-suffix-files-label`, `-label-list`, `-viewer`) in https://github.com/spinalcordtoolbox/manual-correction/commit/f89a9aceca97c7dc6aedf35e3aa950eb8da7ad91
- correction of gmseg in https://github.com/spinalcordtoolbox/manual-correction/commit/291be5f2257af344e1066934698037181be923ad
- selection of viewer (FSLeyes, ITK-SNAP. 3D Slicer is not implemented yet, though) in https://github.com/spinalcordtoolbox/manual-correction/commit/44a54f6937600365f545335cb033ca80bdf881cc
- `fetch_subject_and_session` function (to unify `get_subject` and `get_session` under a single function) in https://github.com/spinalcordtoolbox/manual-correction/commit/0e312aa402f19c4dda09aafc2118c406eae5b84c and https://github.com/spinalcordtoolbox/manual-correction/commit/daf74dcd7ed889f84b326533ff5fdae3df79757c
- `fetch_yaml_config` function to simplify loading of yaml config file among scripts in https://github.com/spinalcordtoolbox/manual-correction/commit/272c4c9cba622172e70edfd027a578a821ea1cfa
- further improvements (such as manipulation with paths, comments to clarify code, etc.)

I would extremely appreciate feedback from SCT users, such as @sandrinebedard, @kiristern, @naga-karthik, @rohanbanerjee, and @mchen1110. You can test the PR using the instructions below or on some dataset you are currently working on.

This PR partly addresses #1. But still, a lot of features describes in https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3353#issuecomment-1380916712 have to be implemented. 

## How to test this PR

1. Clone repo, create `venv`, and install dependencies:

```
git clone https://github.com/spinalcordtoolbox/manual-correction.git
cd manual-correction
git checkout jv/generalize_manual_correction_scripts
python3 -m venv venv
source venv/bin/activate
pip install -r requirements.txt
```

2. Download the [testing dataset](https://www.dropbox.com/s/adkgjqgxn2wj4iq/manual_correction_example_dataset.zip?dl=0). The dataset contains a sample output as provided by `sct_run_batch`. The dataset also includes the `files_to_correct.yml` file with a list of files for manual correction (obtained from the [SCT QC html report](https://spinalcordtoolbox.com/overview/concepts/inspecting-results-qc-fsleyes.html#how-do-i-use-the-qc-report).

3. Run `package_for_correction.py`:

This simulates the real-world workflow in which a dataset is processed on a remote server, and you do not want to copy the whole dataset (GB of data). Instead, only the images and labels that need to be corrected (listed in `files_to_correct.yml`) are zipped by the `package_for_correction.py`:

```
python package_for_correction.py -path-in ~/manual_correction_example_dataset/data_processed -config ~/manual_correction_example_dataset/files_to_correct.yml -o ~/manual_correction_example_dataset/data_to_correct
```

(Now, you would have copied the zipped file from a server to your local machine. Since we are just simulating real-world workflow, the copy from a server to a local machine is skipped for now.)

4. Run `manual_correction.py`:

The `package_for_correction.py` outputs `data_to_correct.zip`. Unzip this archive and run `manual_correction.py`:

```
python manual_correction.py -path-in ~/manual_correction_example_dataset/data_to_correct -config ~/manual_correction_example_dataset/files_to_correct.yml -path-out ~/Desktop/manual_correction_example_dataset -viewer fsleyes
```

Note: you can specify a viewer (FSLeyes, ITK-SNAP) for SC and GM segmentation corrections. (3D Slicer is not implemented yet)

First, you will have to enter your name (which will be used for .json sidecars). Then, the `package_for_correction.py` will iterate across files listed in `files_to_correct.yml`. It will gradually open FSLeyes (or ITK-snap) for SC and GM segmentation correction and sct_label_utils for disc label correction. The script saves manually corrected files under the `derivatives/labels` folder (you can change this folder by the `-path-derivatives` flag). The script also outputs a QC report (--> you can check how you corrected the labels).

Once finished, you can rerun the command. In this case, the script detects manually corrected files under `derivatives/labels` and asks you if you want to overwrite them.

Fixes: https://github.com/spinalcordtoolbox/manual-correction/issues/1