### PR TITLE
Allow iterating across all subjects using wildcard

### DIFF
--- a/manual_correction.py
+++ b/manual_correction.py
@@ -5,24 +5,6 @@
 #
 # For usage, type: python manual_correction.py -h
 #
-# Examples:
-#   * Correcting spinal cord segmentation across all subjects using the wildcard '*' (using FSLeyes as a viewer):
-#       python manual_correction.py -path-in <path_to_dataset> -config config.yml -path-out <output_path> -viewer fsleyes
-#       config.yml:
-#           """
-#           FILES_SEG:
-#               - sub-*_ses-M0_T2w.nii.gz
-#           """
-#
-#   * Correcting spinal cord segmentation across all subjects using the wildcard '*' (using FSLeyes as a viewer and
-#     assuming that the input images have been reoriented to RPI and resampled and thus contain the suffix '_RPI_r'):
-#       python manual_correction.py -path-in <path_to_dataset> -config config.yml -path-out <output_path> -viewer fsleyes -suffix-files-in _RPI_r
-#       config.yml:
-#           """
-#           FILES_SEG:
-#               - sub-*_ses-M0_T2w_RPI_r.nii.gz
-#           """
-#
 # Authors: Jan Valosek, Sandrine Bédard, Naga Karthik, Julien Cohen-Adad
 #
 

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -5,6 +5,24 @@
 #
 # For usage, type: python manual_correction.py -h
 #
+# Examples:
+#   * Correcting spinal cord segmentation across all subjects using the wildcard '*' (using FSLeyes as a viewer):
+#       python manual_correction.py -path-in <path_to_dataset> -config config.yml -path-out <output_path> -viewer fsleyes
+#       config.yml:
+#           """
+#           FILES_SEG:
+#               - sub-*_ses-M0_T2w.nii.gz
+#           """
+#
+#   * Correcting spinal cord segmentation across all subjects using the wildcard '*' (using FSLeyes as a viewer and
+#     assuming that the input images have been reoriented to RPI and resampled and thus contain the suffix '_RPI_r'):
+#       python manual_correction.py -path-in <path_to_dataset> -config config.yml -path-out <output_path> -viewer fsleyes -suffix-files-in _RPI_r
+#       config.yml:
+#           """
+#           FILES_SEG:
+#               - sub-*_ses-M0_T2w_RPI_r.nii.gz
+#           """
+#
 # Authors: Jan Valosek, Sandrine Bédard, Naga Karthik, Julien Cohen-Adad
 #
 
@@ -44,7 +62,8 @@ def get_parser():
         "'FILES_LABEL' lists images associated with vertebral labeling, "
         "and 'FILES_PMJ' lists images associated with pontomedullary junction labeling. "
         "You can validate your .yml file at this website: http://www.yamllint.com/."
-        "Note: if you want to iterate over all subjects, you can use the wildcard '*' (e.g. sub-*_T1w.nii.gz)"
+        "Note: if you want to iterate over all subjects, you can use the wildcard '*' (Examples: sub-*_T1w.nii.gz, "
+        "sub-*_ses-M0_T2w.nii.gz, sub-*_ses-M0_T2w_RPI_r.nii.gz, etc.)"
         "Below is an example .yml file:\n"
         + dedent(
             """
@@ -94,9 +113,11 @@ def get_parser():
     parser.add_argument(
         '-suffix-files-in',
         help=
-        "R|Suffix of the input files. For example: '_RPI_r'."
-        "Note: this flag is useful in cases when the input files have been processed and thus contains a specific "
-        "suffix.",
+        "R|Suffix of the input files."
+        "This flag is useful in cases when the input files have been processed and thus contain a specific suffix."
+        "For example, if the input image listed under '-config' contains the suffix '_RPI_r' "
+        "(e.g., sub-001_T1w_RPI_r.nii.gz), but the label file does not contain this suffix "
+        "(e.g., sub-001_T1w_seg.nii.gz), then you would need to provide the suffix '_RPI_r' to this flag.",
         default=''
     )
     parser.add_argument(

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -44,6 +44,7 @@ def get_parser():
         "'FILES_LABEL' lists images associated with vertebral labeling, "
         "and 'FILES_PMJ' lists images associated with pontomedullary junction labeling. "
         "You can validate your .yml file at this website: http://www.yamllint.com/."
+        "Note: if you want to iterate over all subjects, you can use the wildcard '*' (e.g. sub-*_T1w.nii.gz)"
         "Below is an example .yml file:\n"
         + dedent(
             """
@@ -391,6 +392,10 @@ def main():
                     file_list.remove(file)
             files = file_list  # Rename to use those files instead of the ones to exclude
         if files is not None:
+            # Handle regex (i.e., iterate over all subjects)
+            if '*' in files[0] and len(files) == 1:
+                subject, ses, filename, contrast = utils.fetch_subject_and_session(files[0])
+                files = sorted(glob.glob(os.path.join(utils.get_full_path(args.path_in), subject, ses, contrast, filename)))
             for file in files:
                 # build file names
                 subject, ses, filename, contrast = utils.fetch_subject_and_session(file)

--- a/package_for_correction.py
+++ b/package_for_correction.py
@@ -7,8 +7,8 @@
 # Authors: Jan Valosek, Sandrine Bédard, Julien Cohen-Adad
 #
 
-
 import os
+import glob
 import sys
 import shutil
 import tempfile
@@ -40,6 +40,7 @@ def get_parser():
         ",'FILES_LABEL' lists images associated with vertebral labeling "
         "and 'FILES_PMJ' lists images associated with pontomedullary junction labeling"
         "You can validate your .yml file at this website: http://www.yamllint.com/."
+        "Note: if you want to iterate over all subjects, you can use the wildcard '*' (e.g. sub-*_T1w.nii.gz)"
         "Below is an example .yml file:\n"
         + dedent(
             """
@@ -150,6 +151,10 @@ def main():
     # Loop across files and copy them in the appropriate directory
     # Note: in case the file is listed twice, we just overwrite it in the destination dir.
     for task, files in dict_yml.items():
+        # Handle regex (i.e., iterate over all subjects)
+        if '*' in files[0] and len(files) == 1:
+            subject, ses, filename, contrast = utils.fetch_subject_and_session(files[0])
+            files = sorted(glob.glob(os.path.join(utils.get_full_path(args.path_in), subject, ses, contrast, filename)))
         for file in files:
             if task in suffix_dict.keys():
                 suffix_label = suffix_dict[task]

--- a/utils.py
+++ b/utils.py
@@ -201,7 +201,8 @@ def check_files_exist(dict_files, path_data):
     """
     missing_files = []
     for task, files in dict_files.items():
-        if files is not None:
+        # Do no check if key is empty or if regex is used
+        if files is not None and '*' in files:
             for file in files:
                 subject, ses, filename, contrast = fetch_subject_and_session(file)
                 fname = os.path.join(path_data, subject, ses, contrast, filename)


### PR DESCRIPTION
This PR adds the possibility to iterate across all subjects using the wildcard `*`.

The config file then looks like:

```yaml
FILES_SEG:
   - sub-*_T1w.nii.gz
```

Fixes https://github.com/spinalcordtoolbox/manual-correction/issues/5