### PR TITLE
Add clarity with warning color to log output for missing files and labels

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -219,12 +219,12 @@ def check_files_exist(dict_files, path_data, suffix_dict):
                 if not os.path.exists(fname_label):
                     missing_files_labels.append(fname_label)
     if missing_files:
-        logging.error("The following files are missing: \n{}. \nPlease check that the files listed in the yaml file "
-                      "and the input path are correct.".format(missing_files))
+        logging.error("The following files are missing: \n{}".format(missing_files))
+        logging.warning("\nPlease check that the files listed in the yaml file and the input path are correct.\n")
     if missing_files_labels:
-        logging.error("The following label files are missing: \n{}. \nPlease check that the used suffix '{}' is "
-                      "correct. If not, you can provide custom suffix using '-suffix-files-' flags.".format(
-                        missing_files_labels, suffix_dict[task]))
+        logging.error("The following label files are missing: \n{}".format(missing_files_labels))
+        logging.warning("\nPlease check that the used suffix '{}' is correct. "
+                        "If not, you can provide custom suffix using '-suffix-files-' flags.\n".format(suffix_dict[task]))
 
 
 def check_output_folder(path_bids, folder_derivatives):


### PR DESCRIPTION
## Description

This PR improves the clarity of log by adding warning color to the output of the function `check_files_exist`

### Before
<img width="1279" alt="Capture d’écran 2023-03-10 à 12 15 36" src="https://user-images.githubusercontent.com/68945192/224380630-54ed4f30-3d91-4b1e-b5d1-f9de4965ecb2.png">


### After
<img width="1278" alt="Capture d’écran 2023-03-10 à 12 16 58" src="https://user-images.githubusercontent.com/68945192/224380507-759dc77c-3020-4369-a330-9e958241794d.png">
