### PR TITLE
Limit warnings raised by `check_files_exist`

### DIFF
--- a/manual_correction.py
+++ b/manual_correction.py
@@ -572,13 +572,13 @@ def main():
         'FILES_CENTERLINE': args.suffix_files_centerline    # e.g., _centerline or _label-centerline
     }
 
-    # Check for missing files before starting the whole process
-    if not args.add_seg_only:
-        utils.check_files_exist(dict_yml, utils.get_full_path(args.path_in), suffix_dict)
-
     path_out = utils.get_full_path(args.path_out)
     # check that output folder exists and has write permission
     path_out_deriv = utils.check_output_folder(path_out, args.path_derivatives)
+
+    # Check for missing files before starting the whole process
+    if not args.add_seg_only:
+        utils.check_files_exist(dict_yml, utils.get_full_path(args.path_in), suffix_dict, path_out_deriv)
 
     # Fetch parameters for FSLeyes
     param_fsleyes = ParamFSLeyes(cm=args.fsleyes_cm, dr=args.fsleyes_dr, second_orthoview=args.fsleyes_second_orthoview)


### PR DESCRIPTION
This PR drop warnings raised by `check_files_exist` function when running another round of corrections.

The [check_files_exist](https://github.com/spinalcordtoolbox/manual-correction/blob/6d1e028baa3c959ccbef367d6420b8dc2ed65635/utils.py#L198) function now newly checks (see [here](https://github.com/spinalcordtoolbox/manual-correction/blob/6d1e028baa3c959ccbef367d6420b8dc2ed65635/utils.py#L220-L229)) if labels exist under `derivatives` folder. If so, no warning is raised (because we will be editing precisely these labels under `derivatives`).

Main branch:

<img width="1335" alt="image" src="https://github.com/spinalcordtoolbox/manual-correction/assets/39456460/008dc29d-d31f-4f11-97af-8f626a5f4e08">

This branch:

<img width="1342" alt="image" src="https://github.com/spinalcordtoolbox/manual-correction/assets/39456460/e6873051-de10-4ac4-88c9-bb6877d491e3">

Resolves: #38