### PR TITLE
Fix path confusion when using `manual_correction.py`

### DIFF
--- a/manual_correction.py
+++ b/manual_correction.py
@@ -446,8 +446,8 @@ def check_if_modified(time_one, time_two):
 
 def create_json(fname_nifti, name_rater, modified):
     """
-    Create json sidecar with meta information
-    :param fname_nifti: str: File name of the nifti image to associate with the json sidecar
+    Create/update JSON sidecar with meta information
+    :param fname_nifti: str: File name of the nifti image to associate with the JSON sidecar
     :param name_rater: str: Name of the expert rater
     :param modified: bool: True if the file was modified by the user
     :return:
@@ -455,10 +455,11 @@ def create_json(fname_nifti, name_rater, modified):
     if modified:
         metadata = {'Author': name_rater, 'Date': time.strftime('%Y-%m-%d %H:%M:%S')}
         fname_json = fname_nifti.rstrip('.nii').rstrip('.nii.gz') + '.json'
-        with open(fname_json, 'a') as outfile: # information regarding raters will be added to the file
+        with open(fname_json, 'a') as outfile:  # 'a' - information regarding raters will be appended to the JSON file
             json.dump(metadata, outfile, indent=4)
             # Add last newline
             outfile.write("\n")
+        print("JSON sidecar created/updated: {}".format(fname_json))
 
 
 def ask_if_modify(fname_out, fname_label):

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -90,7 +90,8 @@ def get_parser():
         '-path-img',
         metavar="<folder>",
         required=True,
-        help='Path to the folder where niftii images are stored. Example: ~/<your_dataset>/data_processed',
+        help=
+        "R|Full path to the folder with images (BIDS-compliant).",
     )
     parser.add_argument(
         '-path-label',

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -105,7 +105,7 @@ def get_parser():
         metavar="<folder>",
         help=
         "Path to the folder where corrected labels will be stored. Example: ~/<your_dataset>/data_processed/derivatives/labels"
-        "\nDefault: '-path-img + derivatives/labels' will be used. "
+        "\nIf not specified: '-path-img + derivatives/labels' will be used. "
         "If specified path does not exist, out path will be created",
         default=''
     )

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -650,27 +650,18 @@ def main():
                     fname_other_contrast = None
                 # Construct absolute path to the input label (segmentation, labeling etc.) file
                 # For example: '/Users/user/dataset/data_processed/sub-001/anat/sub-001_T2w_seg.nii.gz'
-                temp_fname_label = utils.add_suffix(os.path.join(path_label, subject, ses, contrast, filename), suffix_dict[task])
-                # Check if label exists else add or remove '-manual' to check all the combinations.
-                # The final path still may not exist leading to the creation of a new out file.
-                # The idea is to make the code robust regarding non consistent datasets were both
-                # modified and non modified are present.
-                if os.path.exists(temp_fname_label):
-                    fname_label = temp_fname_label
-                else:
-                    if '-manual' in temp_fname_label:
-                        fname_label = "".join(temp_fname_label.split('-manual')) # Remove manual
-                    else:
-                        fname_label = utils.add_suffix(temp_fname_label, '-manual') # Add manual
+                fname_label = utils.add_suffix(os.path.join(path_label, subject, ses, contrast, filename), suffix_dict[task])
                 
                 # Construct absolute path to the output file (i.e., path where manually corrected file will be saved)
-                # For example: '/Users/user/dataset/data_processed/sub-001/anat/sub-001_T2w_seg-manual.nii.gz'
-                # The suffix '-manual' is also added if not already present
+                # For example: '/Users/user/dataset/data_processed/sub-001/anat/sub-001_T2w_seg.nii.gz'
+                # The information regarding the modified data will be stored within the sidecar .json file
                 temp_fname_out = utils.add_suffix(os.path.join(path_out, subject, ses, contrast, filename), suffix_dict[task])
+                
+                # This condition is used to remove the suffix -manual from our current datasets (can be deleted later)
                 if '-manual' in temp_fname_out:
-                    fname_out = temp_fname_out
+                    fname_out = temp_fname_out.replace('-manual','')
                 else:
-                    fname_out = utils.add_suffix(temp_fname_out, '-manual')
+                    fname_out = temp_fname_out
                 
                 # Create subject folder in output if they do not exist
                 os.makedirs(os.path.join(path_out, subject, ses, contrast), exist_ok=True)

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -97,16 +97,16 @@ def get_parser():
         '-path-label',
         metavar="<folder>",
         help=
-        "R|Full path to the folder with labels (BIDS-compliant). Examples: '~/<your_dataset>/derivatives/labels' or '~/<your_dataset>/derivatives/labels_softseg'"
-        "If not provided, '-path-img' will be used assuming that the labels are located in the same directory as images.",
+        "R|Full path to the folder with labels (BIDS-compliant). Examples: '~/<your_dataset>/derivatives/labels' or '~/<your_dataset>/derivatives/labels_softseg' "
+        "If not provided, '-path-img' + 'derivatives/labels' will be used. ",
         default=''
     )
     parser.add_argument(
         '-path-out',
         metavar="<folder>",
         help=
-        "R| Full path to the folder where corrected labels will be stored. Example: '~/<your_dataset>/derivatives/labels'"
-        "If not provided, '-path-img' + 'derivatives/labels' will be used."
+        "R| Full path to the folder where corrected labels will be stored. Example: '~/<your_dataset>/derivatives/labels' "
+        "If not provided, '-path-img' + 'derivatives/labels' will be used. "
         "Note: If the specified path does not exist, it will be created.",
         default=''
     )
@@ -470,7 +470,7 @@ def ask_if_modify(fname_out, fname_label):
     :param fname_label: input label which will be modified, example: <PATH_DATA>/data_processed/sub-001/anat/sub-001_T2w_seg.nii.gz
     :return:
     """
-    # Check if th output file already exists
+    # Check if the output file already exists
     if os.path.isfile(fname_out):
         answer = None
         while answer not in ("y", "n"):
@@ -571,7 +571,7 @@ def main():
     path_img = utils.get_full_path(args.path_img)
     
     if args.path_label == '':
-        path_label = path_img
+        path_label = os.path.join(args.path_img, "derivatives/labels")
     else:
         path_label = utils.get_full_path(args.path_label)
     
@@ -672,7 +672,7 @@ def main():
                 else:
                     fname_out = utils.add_suffix(temp_fname_out, '-manual')
                 
-                # Create output folders under derivative if they do not exist
+                # Create subject folder in output if they do not exist
                 os.makedirs(os.path.join(path_out, subject, ses, contrast), exist_ok=True)
                 if not args.qc_only:
                     # Check if the output file already exists. If so, asks user if they want to modify it.

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -105,9 +105,9 @@ def get_parser():
         '-path-out',
         metavar="<folder>",
         help=
-        "Path to the folder where corrected labels will be stored. Example: ~/<your_dataset>/data_processed/derivatives/labels"
-        "\nIf not specified: '-path-img + derivatives/labels' will be used. "
-        "If specified path does not exist, out path will be created",
+        "R| Full path to the folder where corrected labels will be stored. Example: '~/<your_dataset>/derivatives/labels'"
+        "If not provided, '-path-img' + 'derivatives/labels' will be used."
+        "Note: If the specified path does not exist, it will be created.",
         default=''
     )
     parser.add_argument(

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -455,7 +455,7 @@ def create_json(fname_nifti, name_rater, modified):
     if modified:
         metadata = {'Author': name_rater, 'Date': time.strftime('%Y-%m-%d %H:%M:%S')}
         fname_json = fname_nifti.rstrip('.nii').rstrip('.nii.gz') + '.json'
-        with open(fname_json, 'w') as outfile:
+        with open(fname_json, 'a') as outfile: # information regarding raters will be added to the file
             json.dump(metadata, outfile, indent=4)
             # Add last newline
             outfile.write("\n")

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -669,13 +669,7 @@ def main():
                 # Construct absolute path to the output file (i.e., path where manually corrected file will be saved)
                 # For example: '/Users/user/dataset/data_processed/sub-001/anat/sub-001_T2w_seg.nii.gz'
                 # The information regarding the modified data will be stored within the sidecar .json file
-                temp_fname_out = utils.add_suffix(os.path.join(path_out, subject, ses, contrast, filename), suffix_dict[task])
-                
-                # This condition is used to remove the suffix -manual from our current datasets (can be deleted later)
-                if '-manual' in temp_fname_out:
-                    fname_out = temp_fname_out.replace('-manual','')
-                else:
-                    fname_out = temp_fname_out
+                fname_out = utils.add_suffix(os.path.join(path_out, subject, ses, contrast, filename), suffix_dict[task])
                 
                 # Create subject folder in output if they do not exist
                 os.makedirs(os.path.join(path_out, subject, ses, contrast), exist_ok=True)

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -158,8 +158,8 @@ def get_parser():
     parser.add_argument(
         '-label-disc-list',
         help="Comma-separated list containing individual values and/or intervals for disc labeling. Example: '1:4,6,8' "
-             "or 1:20 (default)",
-        default='1:20'
+             "or 1:25 (default)",
+        default='1:25'
     )
     parser.add_argument(
         '-viewer',

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -97,8 +97,8 @@ def get_parser():
         '-path-label',
         metavar="<folder>",
         help=
-        "Path to the folder where labels are stored. Example: ~/<your_dataset>/data_processed/derivatives/labels"
-        "\nDefault: -path-img will be used",
+        "R|Full path to the folder with labels (BIDS-compliant). Examples: '~/<your_dataset>/derivatives/labels' or '~/<your_dataset>/derivatives/labels_softseg'"
+        "If not provided,  '-path-img' will be used assuming that the labels are located in the same directory as images.",
         default=''
     )
     parser.add_argument(

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -98,7 +98,7 @@ def get_parser():
         metavar="<folder>",
         help=
         "R|Full path to the folder with labels (BIDS-compliant). Examples: '~/<your_dataset>/derivatives/labels' or '~/<your_dataset>/derivatives/labels_softseg'"
-        "If not provided,  '-path-img' will be used assuming that the labels are located in the same directory as images.",
+        "If not provided, '-path-img' will be used assuming that the labels are located in the same directory as images.",
         default=''
     )
     parser.add_argument(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -96,7 +96,7 @@ def test_check_files_exist_all_files_exist(tmp_path, caplog):
     }
 
     # run the function
-    check_files_exist(dict_files, path_data, suffix_dict)
+    check_files_exist(dict_files, path_img=path_data, path_label=path_data, suffix_dict=suffix_dict)
 
     # check that no error or warning was raised
     assert len(caplog.records) == 0
@@ -122,7 +122,7 @@ def test_check_files_exist_missing_file(tmp_path, caplog):
     }
 
     # run the function
-    check_files_exist(dict_files, path_data, suffix_dict)
+    check_files_exist(dict_files, path_img=path_data, path_label=path_data, suffix_dict=suffix_dict)
 
     # Assert that an error or warning message was logged for the missing files
     assert any('The following files are missing' in rec.message for rec in caplog.records)

--- a/utils.py
+++ b/utils.py
@@ -217,8 +217,7 @@ def check_files_exist(dict_files, path_img, path_label, suffix_dict):
                 # Construct absolute path to the input label (segmentation, labeling etc.) file
                 # For example: '/Users/user/dataset/data_processed/sub-001/anat/sub-001_T2w_seg.nii.gz'
                 fname_label = add_suffix(os.path.join(path_label, subject, ses, contrast, filename), suffix_dict[task])
-                fname_label_manual = add_suffix(fname_label, '-manual')
-                if not os.path.exists(fname_label) and not os.path.exists(fname_label_manual):
+                if not os.path.exists(fname_label):
                     missing_files_labels.append(fname_label)
     if missing_files:
         logging.warning("The following files are missing: \n{}".format(missing_files))

--- a/utils.py
+++ b/utils.py
@@ -217,7 +217,8 @@ def check_files_exist(dict_files, path_img, path_label, suffix_dict):
                 # Construct absolute path to the input label (segmentation, labeling etc.) file
                 # For example: '/Users/user/dataset/data_processed/sub-001/anat/sub-001_T2w_seg.nii.gz'
                 fname_label = add_suffix(os.path.join(path_label, subject, ses, contrast, filename), suffix_dict[task])
-                if not os.path.exists(fname_label):
+                fname_label_manual = add_suffix(fname_label, '-manual')
+                if not os.path.exists(fname_label) and not os.path.exists(fname_label_manual):
                     missing_files_labels.append(fname_label)
     if missing_files:
         logging.warning("The following files are missing: \n{}".format(missing_files))


### PR DESCRIPTION
## Description

This PR addresses several issues related to path use with manual correction script

To avoid future confusions regarding the [different use cases](https://github.com/spinalcordtoolbox/manual-correction/issues/44) of the script `manual_correction.py`, this PR allows the user to directly specify:
- the folder where images are stored using `-path-img`
- the folder where labels are stored using `-path-label`
- the folder where corrected labels will be stored using `-path-out`

Some additions to code were also done to improve robustness regarding the use of the "-manual" suffix and more, see related issues.

## Related issues

https://github.com/spinalcordtoolbox/manual-correction/issues/51
https://github.com/spinalcordtoolbox/manual-correction/issues/47
https://github.com/spinalcordtoolbox/manual-correction/issues/41
https://github.com/spinalcordtoolbox/manual-correction/issues/40
https://github.com/spinalcordtoolbox/manual-correction/issues/32