### PR TITLE
Skip QC if label file is empty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Python 3
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8.17
+          python-version: 3.8.18
 
       - name: Install dependencies
         run: |

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -22,6 +22,7 @@ import coloredlogs
 import glob
 import json
 import os
+import logging
 import sys
 import shutil
 from textwrap import dedent
@@ -588,7 +589,7 @@ def generate_qc(fname, fname_label, task, fname_qc, subject, config_file, qc_les
     img_label = nib.load(fname_label)
     data_label = img_label.get_fdata()
     if np.sum(data_label) == 0:
-        print(f"WARNING: {fname_label} is empty. Skipping QC.\n")
+        logging.warning(f"File {fname_label} is empty. Skipping QC.\n")
         return
 
     # Lesion QC needs also SC segmentation for cropping

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -585,12 +585,15 @@ def generate_qc(fname, fname_label, task, fname_qc, subject, config_file, qc_les
     :param suffix_dict: dictionary of suffixes
     :return:
     """
-    # Check if fname_label is empty (i.e., no lesion was drawn in MS patient), if so, skip QC
-    img_label = nib.load(fname_label)
-    data_label = img_label.get_fdata()
-    if np.sum(data_label) == 0:
-        logging.warning(f"File {fname_label} is empty. Skipping QC.\n")
-        return
+    # Not all sct_qc -p functions support empty label files. Check if the label file is empty and skip QC if so.
+    # Context: https://github.com/spinalcordtoolbox/manual-correction/issues/60#issuecomment-1720280352
+    skip_qc_list = ['FILES_LABEL', 'FILES_COMPRESSION', 'FILES_PMJ', 'FILES_CENTERLINE']
+    if task in skip_qc_list:
+        img_label = nib.load(fname_label)
+        data_label = img_label.get_fdata()
+        if np.sum(data_label) == 0:
+            logging.warning(f"File {fname_label} is empty. Skipping QC.\n")
+            return
 
     # Lesion QC needs also SC segmentation for cropping
     if task == 'FILES_LESION':

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -31,6 +31,9 @@ import subprocess
 
 import utils
 
+import numpy as np
+import nibabel as nib
+
 
 def get_parser():
     """
@@ -581,6 +584,13 @@ def generate_qc(fname, fname_label, task, fname_qc, subject, config_file, qc_les
     :param suffix_dict: dictionary of suffixes
     :return:
     """
+    # Check if fname_label is empty (i.e., no lesion was drawn in MS patient), if so, skip QC
+    img_label = nib.load(fname_label)
+    data_label = img_label.get_fdata()
+    if np.sum(data_label) == 0:
+        print(f"WARNING: {fname_label} is empty. Skipping QC.\n")
+        return
+
     # Lesion QC needs also SC segmentation for cropping
     if task == 'FILES_LESION':
         # Construct SC segmentation file name


### PR DESCRIPTION
Check if the label file is empty (i.e., no lesion was drawn in MS patient); if so, skip QC.

Resolves: https://github.com/spinalcordtoolbox/manual-correction/issues/60