### PR TITLE
Do not skip subject if other contrast does not exist

### DIFF
--- a/manual_correction.py
+++ b/manual_correction.py
@@ -783,6 +783,10 @@ def main():
                         else:
                             other_contrast_filename = subject + '_' + ses + '_' + args.load_other_contrast + '.nii.gz'
                         fname_other_contrast = os.path.join(path_img, subject, ses, contrast, other_contrast_filename)
+                        # Check if other contrast exists
+                        if not os.path.isfile(fname_other_contrast):
+                            print(f'WARNING: {fname_other_contrast} not found. Skipping...')
+                            fname_other_contrast = None
                     else:
                         fname_other_contrast = None
                     # Construct absolute path to the input label (segmentation, labeling etc.) file

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -264,9 +264,9 @@ def create_fsleyes_script():
     Create a custom Python script to interact with the FSLeyes API.
     Note: the second orthoview cannot be opened from the CLI, instead, FSLeyes API via a custom Python script must
     be used. For details, see: https://www.jiscmail.ac.uk/cgi-bin/wa-jisc.exe?A2=FSL;ab356891.2301
-    :param fname: path of the input image.
+    :param fname: path of the input image
     :param fname_seg_out: path to the derivative label file
-    :param fname_other_contrast: path of the other contrast to be loaded in FSLeyes.
+    :param fname_other_contrast: path of the other contrast to be loaded in FSLeyes
     :param param_fsleyes:
     :return:
     """
@@ -357,6 +357,9 @@ def correct_segmentation(fname, fname_seg_out, fname_other_contrast, viewer, par
             # -S, --skipfslcheck    Skip $FSLDIR check/warning
             # -dr, --displayRange   Set display range (min max) for the specified overlay
             # -cm, --cmap           Set colour map for the specified overlay
+            # -r, --runscript       Run custom FSLeyes script
+
+            # Load a second contrast/image
             if fname_other_contrast:
                 # Open a second orthoview (i.e., open two orthoviews next to each other)
                 if param_fsleyes.second_orthoview:
@@ -367,7 +370,7 @@ def correct_segmentation(fname, fname_seg_out, fname_other_contrast, viewer, par
                                            fname, '-dr', param_fsleyes.min_dr, param_fsleyes.max_dr,
                                            fname_other_contrast,
                                            fname_seg_out, '-cm', param_fsleyes.cm])
-                # No second orthoview
+                # No second orthoview - open both contrasts/images in the same orthoview
                 else:
                     subprocess.check_call(['fsleyes',
                                            '-S',
@@ -382,7 +385,7 @@ def correct_segmentation(fname, fname_seg_out, fname_other_contrast, viewer, par
                                        '-r', fname_script,
                                        fname, '-dr', param_fsleyes.min_dr, param_fsleyes.max_dr,
                                        fname_seg_out, '-cm', param_fsleyes.cm])
-            # No second contrast, no second orthoview
+            # Only a single contrast/image in a single orthoview
             else:
                 subprocess.check_call(['fsleyes',
                                        '-S',

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -773,8 +773,7 @@ def main():
                 if '*' in files[0] and len(files) == 1:
                     subject, ses, filename, contrast = utils.fetch_subject_and_session(files[0])
                     # Get list of files recursively
-                    glob_files = sorted(glob.glob(os.path.join(path_img, '**', filename),
-                                            recursive=True))
+                    glob_files = sorted(glob.glob(os.path.join(path_img, '**', filename), recursive=True))
                     # Get list of already corrected files
                     if task.replace('FILES', 'CORR') in dict_yml.keys():
                         corr_files = dict_yml[task.replace('FILES', 'CORR')]

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -264,11 +264,7 @@ def create_fsleyes_script():
     Create a custom Python script to interact with the FSLeyes API.
     Note: the second orthoview cannot be opened from the CLI, instead, FSLeyes API via a custom Python script must
     be used. For details, see: https://www.jiscmail.ac.uk/cgi-bin/wa-jisc.exe?A2=FSL;ab356891.2301
-    :param fname: path of the input image
-    :param fname_seg_out: path to the derivative label file
-    :param fname_other_contrast: path of the other contrast to be loaded in FSLeyes
-    :param param_fsleyes:
-    :return:
+    :return: fname_script: filename of the custom Python script.
     """
     python_script = [
         "ortho_left = frame.addViewPanel(OrthoPanel)",


### PR DESCRIPTION
This PR:
- Add a condition to check if other contrast (specified by the `-load-other-contrast` flag) exists. If the other contrast does not exist, only the main contrast (specified in the config file provided by the `-config` flag) is open  - https://github.com/spinalcordtoolbox/manual-correction/commit/675a894bf45c6ad7a87dee9aa6aaa2161ca1b10e, https://github.com/spinalcordtoolbox/manual-correction/commit/a69d30e92d98a68e84ffd6ddc418a749cdb9c921
- Refactor the `correct_segmentation()` function to make it shorter and easier to follow - https://github.com/spinalcordtoolbox/manual-correction/commit/362ee0607dcf683788f512a4c434048e17a1b168

Resolves: https://github.com/spinalcordtoolbox/manual-correction/issues/46