### PR TITLE
Use `os.system` instead of `subprocess.check_call` for FSLeyes and ITKsnap commands

### DIFF
--- a/manual_correction.py
+++ b/manual_correction.py
@@ -330,15 +330,11 @@ def correct_segmentation(fname, fname_seg_out, fname_other_contrast, viewer, par
         # Note: command line differs for macOs/Linux and Windows
         if shutil.which('itksnap') is not None:  # Check if command 'itksnap' exists
             # macOS and Linux
-            subprocess.check_call(['itksnap',
-                                   '-g', fname,
-                                   '-s', fname_seg_out])
+            os.system(f'itksnap -g {fname} -s {fname_seg_out}')
             
         elif shutil.which('ITK-SNAP') is not None:  # Check if command 'ITK-SNAP' exists
             # Windows
-            subprocess.check_call(['ITK-SNAP',
-                                   '-g', fname,
-                                   '-s', fname_seg_out])
+            os.system(f'ITK-SNAP -g {fname} -s {fname_seg_out}')
         else:
             viewer_not_found(viewer)
     # launch FSLeyes
@@ -362,34 +358,21 @@ def correct_segmentation(fname, fname_seg_out, fname_other_contrast, viewer, par
                 # (-r flag)
                 if param_fsleyes.second_orthoview:
                     fname_script = create_fsleyes_script()
-                    subprocess.check_call(['fsleyes',
-                                           '-S',
-                                           '-r', fname_script,
-                                           fname, '-dr', param_fsleyes.min_dr, param_fsleyes.max_dr,
-                                           fname_other_contrast,
-                                           fname_seg_out, '-cm', param_fsleyes.cm])
+                    os.system(f'fsleyes -S -r {fname_script} {fname} -dr {param_fsleyes.min_dr} {param_fsleyes.max_dr} '
+                              f'{fname_other_contrast} {fname_seg_out} -cm {param_fsleyes.cm}')
                 # No second orthoview
                 else:
-                    subprocess.check_call(['fsleyes',
-                                           '-S',
-                                           fname, '-dr', param_fsleyes.min_dr, param_fsleyes.max_dr,
-                                           fname_other_contrast,
-                                           fname_seg_out, '-cm', param_fsleyes.cm])
-            # Open a second orthoview without second contrast
+                    os.system(f'fsleyes -S {fname} -dr {param_fsleyes.min_dr} {param_fsleyes.max_dr} '
+                              f'{fname_other_contrast} {fname_seg_out} -cm {param_fsleyes.cm}')
+            # Open a second orthoview without second contrast using a custom Python script (-r flag)
             elif param_fsleyes.second_orthoview:
                 fname_script = create_fsleyes_script()
-                subprocess.check_call(['fsleyes',
-                                       '-S',
-                                       '-r', fname_script,
-                                       fname, '-dr', param_fsleyes.min_dr, param_fsleyes.max_dr,
-                                       fname_seg_out, '-cm', param_fsleyes.cm])
+                os.system(f'fsleyes -S -r {fname_script} {fname} -dr {param_fsleyes.min_dr} {param_fsleyes.max_dr} '
+                          f'{fname_seg_out} -cm {param_fsleyes.cm}')
             # No second contrast, no second orthoview
             else:
-                subprocess.check_call(['fsleyes',
-                                       '-S',
-                                       fname,
-                                       '-dr', param_fsleyes.min_dr, param_fsleyes.max_dr,
-                                       fname_seg_out, '-cm', param_fsleyes.cm])
+                os.system(f'fsleyes -S {fname} -dr {param_fsleyes.min_dr} {param_fsleyes.max_dr} {fname_seg_out} -cm '
+                          f'{param_fsleyes.cm}')
         else:
             viewer_not_found(viewer)
     # launch 3D Slicer


### PR DESCRIPTION
FSLeyes often prints a lot of warnings into the CLI (for example, when switching between overlays, changing colormap, etc.). The usage of `subprocess.check_call` (introduced in https://github.com/spinalcordtoolbox/manual-correction/commit/8aa0e3a47b23e030751d8056b773c7cdde265dba to replace `os.system`) terminates the [manual_correction.py](https://github.com/spinalcordtoolbox/manual-correction/blob/main/manual_correction.py) script in such cases.

This PR thus bring back `os.system` for FSLeyes and ITKsnap commands.