### PR TITLE
Handle KeyErrors more gracefully if user marks `FILES_REG` as a `qc_fail.yml`

### DIFF
--- a/manual_correction.py
+++ b/manual_correction.py
@@ -757,6 +757,9 @@ def main():
     for task, files in dict_yml.items():
         if task.startswith('FILES'):
             # Check if task is in suffix_dict.keys(), if not, skip it
+            # Note that this check is done after the task.startswith('FILES') check because the manual-correction
+            # script should ignore keys that start with CORR (CORR keys are used to track the manual correction
+            # progress)
             if task not in suffix_dict.keys():
                 logging.warning("WARNING: {} is not a valid task. Skipping it.".format(task))
                 continue

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -756,6 +756,10 @@ def main():
     # Perform manual corrections
     for task, files in dict_yml.items():
         if task.startswith('FILES'):
+            # Check if task is in suffix_dict.keys(), if not, skip it
+            if task not in suffix_dict.keys():
+                logging.warning("WARNING: {} is not a valid task. Skipping it.".format(task))
+                continue
             # Get the list of segmentation files to add to derivatives, excluding the manually corrected files in -config.
             # TODO: probably extend also for other tasks (such as FILES_GMSEG)
             if args.add_seg_only and task == 'FILES_SEG':

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -167,7 +167,7 @@ def test_check_files_exist_missing_file(tmp_path, caplog):
     assert any('Please check that the files listed in the yaml file and the input path are correct' in rec.message for rec in caplog.records)
     assert any('BIDS/sub-001/ses-01/anat/sub-001_ses-01_T1w_seg.nii.gz' in rec.message for rec in caplog.records)
     assert any('BIDS/sub-002/ses-01/anat/sub-001_ses-01_T2star_gmseg.nii.gz' in rec.message for rec in caplog.records)
-    assert any("Please check that the used suffix '_gmseg' is correct" in rec.message for rec in caplog.records)
+    assert any("Please check that the used suffix ['_gmseg', '_seg'] is correct" in rec.message for rec in caplog.records)
 
 
 def test_track_corrections(tmp_path):

--- a/utils.py
+++ b/utils.py
@@ -209,6 +209,7 @@ def check_files_exist(dict_yml, path_img, path_label, suffix_dict):
     """
     missing_files = []
     missing_files_labels = []
+    missing_suffixes = set()
     for task, files in dict_yml.items():
         if task.startswith('FILES') and files:
             # Check if task is in suffix_dict.keys(), if not, skip it
@@ -227,6 +228,7 @@ def check_files_exist(dict_yml, path_img, path_label, suffix_dict):
                     fname_label = add_suffix(os.path.join(path_label, subject, ses, contrast, filename), suffix_dict[task])
                     if not os.path.exists(fname_label):
                         missing_files_labels.append(fname_label)
+                        missing_suffixes.add(suffix_dict[task])
     if missing_files:
         logging.warning("The following files are missing: \n{}".format(missing_files))
         logging.warning("\nPlease check that the files listed in the yaml file and the input path are correct.\n")
@@ -234,7 +236,7 @@ def check_files_exist(dict_yml, path_img, path_label, suffix_dict):
         logging.warning("If you are creating label(s) from scratch, ignore the following message.")
         logging.warning("\nThe following label files are missing: \n{}".format(missing_files_labels))
         logging.warning("\nPlease check that the used suffix '{}' is correct. "
-                        "If not, you can provide custom suffix using '-suffix-files-' flags.\n".format(suffix_dict[task]))
+                        "If not, you can provide custom suffix using '-suffix-files-' flags.\n".format(sorted(missing_suffixes)))
 
 
 def check_output_folder(path_bids):
@@ -327,4 +329,4 @@ def track_corrections(files_dict, config_path, file_path, task):
 
     return files_dict
 
-        
+

--- a/utils.py
+++ b/utils.py
@@ -235,7 +235,7 @@ def check_files_exist(dict_yml, path_img, path_label, suffix_dict):
     if missing_files_labels:
         logging.warning("If you are creating label(s) from scratch, ignore the following message.")
         logging.warning("\nThe following label files are missing: \n{}".format(missing_files_labels))
-        logging.warning("\nPlease check that the used suffix '{}' is correct. "
+        logging.warning("\nPlease check that the used suffix {} is correct. "
                         "If not, you can provide custom suffix using '-suffix-files-' flags.\n".format(sorted(missing_suffixes)))
 
 

--- a/utils.py
+++ b/utils.py
@@ -211,6 +211,10 @@ def check_files_exist(dict_yml, path_img, path_label, suffix_dict):
     missing_files_labels = []
     for task, files in dict_yml.items():
         if task.startswith('FILES') and files:
+            # Check if task is in suffix_dict.keys(), if not, skip it
+            if task not in suffix_dict.keys():
+                logging.warning("WARNING: {} is not a valid task. Skipping it.".format(task))
+                continue
             # Do no check if key is empty or if regex is used
             if files is not None and '*' not in files[0]:
                 for file in files:


### PR DESCRIPTION
The script now skips unsupported tasks. For example, for the following config file:

```yml
FILES_REG:
- sub-001_T2w.nii.gz
FILES_SEG:
- sub-*_T2w.nii.gz
```

The script now prints warning and skips `FILES_REG`:

```console
...
WARNING: FILES_REG is not a valid task. Skipping it.
...
```


Resolves: https://github.com/spinalcordtoolbox/manual-correction/issues/71