### PR TITLE
Add `"Name"` and `"SpatialReference"` key-value pair to JSON sidecar 

### DIFF
--- a/manual_correction.py
+++ b/manual_correction.py
@@ -525,13 +525,13 @@ def update_json(fname_nifti, name_rater, modified):
 
     # If the label was modified, add "Note": "Manually corrected" to the JSON sidecar
     if modified:
-        json_dict['GeneratedBy'].append({'Author': name_rater,
-                                         'Note': 'Manually corrected',
+        json_dict['GeneratedBy'].append({'Name': 'Manually corrected',
+                                         'Author': name_rater,
                                          'Date': time.strftime('%Y-%m-%d %H:%M:%S')})
     # If the was not modified, add "Note": ""Visually verified"" to the JSON sidecar
     else:
-        json_dict['GeneratedBy'].append({'Author': name_rater,
-                                         'Note': 'Visually verified',
+        json_dict['GeneratedBy'].append({'Name': 'Visually verified',
+                                         'Author': name_rater,
                                          'Date': time.strftime('%Y-%m-%d %H:%M:%S')})
 
     # Write the data to the JSON file

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -508,7 +508,7 @@ def update_json(fname_nifti, name_rater, modified):
     """
     fname_json = fname_nifti.replace('.gz', '').replace('.nii', '.json')
 
-    # Check if the json file already exists
+    # Check if the json file already exists, if so, open it
     if os.path.exists(fname_json):
         # Read already existing json file
         with open(fname_json, "r") as outfile:  # r to read
@@ -517,6 +517,7 @@ def update_json(fname_nifti, name_rater, modified):
         # Special check to fix all of our current json files (Might be deleted later)
         if 'GeneratedBy' not in json_dict.keys():
             json_dict = {'GeneratedBy': [json_dict]}
+    # If the json file does not exist, initialize a new one
     else:
         # Init new json dict
         json_dict = {'GeneratedBy': []}

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -520,7 +520,8 @@ def update_json(fname_nifti, name_rater, modified):
     # If the json file does not exist, initialize a new one
     else:
         # Init new json dict
-        json_dict = {'GeneratedBy': []}
+        json_dict = {'SpatialReference': 'orig',
+                     'GeneratedBy': []}
 
     # If the label was modified, add "Note": "Manually corrected" to the JSON sidecar
     if modified:

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -483,27 +483,11 @@ def get_modification_time(fname):
     return datetime.datetime.fromtimestamp(os.path.getmtime(fname))
 
 
-def check_if_modified(time_one, time_two):
-    """
-    Check if the file was modified by the user. Return True if the file was modified, False otherwise.
-    :param time_one: modification time of the file before viewing
-    :param time_two: modification time of the file after viewing
-    :return:
-    """
-    if time_one != time_two:
-        print("The label file was modified.")
-        return True
-    else:
-        print("The label file was not modified.")
-        return False
-
-
-def update_json(fname_nifti, name_rater, modified):
+def update_json(fname_nifti, name_rater):
     """
     Create/update JSON sidecar with meta information
     :param fname_nifti: str: File name of the nifti image to associate with the JSON sidecar
     :param name_rater: str: Name of the expert rater
-    :param modified: bool: True if the file was modified by the user
     :return:
     """
     fname_json = fname_nifti.replace('.gz', '').replace('.nii', '.json')
@@ -523,16 +507,10 @@ def update_json(fname_nifti, name_rater, modified):
         json_dict = {'SpatialReference': 'orig',
                      'GeneratedBy': []}
 
-    # If the label was modified, add "Name": "Manual" to the JSON sidecar
-    if modified:
-        json_dict['GeneratedBy'].append({'Name': 'Manual',
-                                         'Author': name_rater,
-                                         'Date': time.strftime('%Y-%m-%d %H:%M:%S')})
-    # If the was not modified, add "Name": ""Visually verified"" to the JSON sidecar
-    else:
-        json_dict['GeneratedBy'].append({'Name': 'Visually verified',
-                                         'Author': name_rater,
-                                         'Date': time.strftime('%Y-%m-%d %H:%M:%S')})
+    # If the label was modified or just checked, add "Name": "Manual" to the JSON sidecar
+    json_dict['GeneratedBy'].append({'Name': 'Manual',
+                                     'Author': name_rater,
+                                     'Date': time.strftime('%Y-%m-%d %H:%M:%S')})
 
     # Write the data to the JSON file
     with open(fname_json, 'w') as outfile:  # w to overwrite the file
@@ -895,11 +873,10 @@ def main():
                             if args.add_seg_only:
                                 # We are passing modified=True because we are adding a new segmentation and we want
                                 # to create a JSON file
-                                update_json(fname_out, name_rater, modified=True)
+                                update_json(fname_out, name_rater)
                             # Generate QC report
                             else:
-                                modified = check_if_modified(time_one, time_two)
-                                update_json(fname_out, name_rater, modified)
+                                update_json(fname_out, name_rater)
                                 # Generate QC report
                                 generate_qc(fname, fname_out, task, fname_qc, subject, args.config, args.qc_lesion_plane, suffix_dict)
 

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -523,12 +523,12 @@ def update_json(fname_nifti, name_rater, modified):
         json_dict = {'SpatialReference': 'orig',
                      'GeneratedBy': []}
 
-    # If the label was modified, add "Note": "Manually corrected" to the JSON sidecar
+    # If the label was modified, add "Name": "Manual" to the JSON sidecar
     if modified:
         json_dict['GeneratedBy'].append({'Name': 'Manually corrected',
                                          'Author': name_rater,
                                          'Date': time.strftime('%Y-%m-%d %H:%M:%S')})
-    # If the was not modified, add "Note": ""Visually verified"" to the JSON sidecar
+    # If the was not modified, add "Name": ""Visually verified"" to the JSON sidecar
     else:
         json_dict['GeneratedBy'].append({'Name': 'Visually verified',
                                          'Author': name_rater,

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -525,7 +525,7 @@ def update_json(fname_nifti, name_rater, modified):
 
     # If the label was modified, add "Name": "Manual" to the JSON sidecar
     if modified:
-        json_dict['GeneratedBy'].append({'Name': 'Manually corrected',
+        json_dict['GeneratedBy'].append({'Name': 'Manual',
                                          'Author': name_rater,
                                          'Date': time.strftime('%Y-%m-%d %H:%M:%S')})
     # If the was not modified, add "Name": ""Visually verified"" to the JSON sidecar

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -498,9 +498,12 @@ def update_json(fname_nifti, name_rater):
         with open(fname_json, "r") as outfile:  # r to read
             json_dict = json.load(outfile)
 
-        # Special check to fix all of our current json files (Might be deleted later)
+        # Special checks to fix all of our current json files (Might be deleted later)
         if 'GeneratedBy' not in json_dict.keys():
             json_dict = {'GeneratedBy': [json_dict]}
+        if 'SpatialReference' not in json_dict.keys():
+            json_dict['SpatialReference'] = 'orig'
+    
     # If the json file does not exist, initialize a new one
     else:
         # Init new json dict

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -507,26 +507,37 @@ def update_json(fname_nifti, name_rater, modified):
     :return:
     """
     fname_json = fname_nifti.replace('.gz', '').replace('.nii', '.json')
+
+    # Check if the json file already exists
+    if os.path.exists(fname_json):
+        # Read already existing json file
+        with open(fname_json, "r") as outfile:  # r to read
+            json_dict = json.load(outfile)
+
+        # Special check to fix all of our current json files (Might be deleted later)
+        if 'GeneratedBy' not in json_dict.keys():
+            json_dict = {'GeneratedBy': [json_dict]}
+    else:
+        # Init new json dict
+        json_dict = {'GeneratedBy': []}
+
+    # If the label was modified, add "Note": "Manually corrected" to the JSON sidecar
     if modified:
-        if os.path.exists(fname_json):
-            # Read already existing json file
-            with open(fname_json, "r") as outfile:  # r to read
-                json_dict = json.load(outfile)
-            
-            # Special check to fix all of our current json files (Might be deleted later)
-            if 'GeneratedBy' not in json_dict.keys():
-                json_dict = {'GeneratedBy': [json_dict]}
-        else:
-            # Init new json dict
-            json_dict = {'GeneratedBy': []}
-        
-        # Add new author with time and date
-        json_dict['GeneratedBy'].append({'Author': name_rater, 'Date': time.strftime('%Y-%m-%d %H:%M:%S')})
-        with open(fname_json, 'w') as outfile: # w to overwrite the file
-            json.dump(json_dict, outfile, indent=4)
-            # Add last newline
-            outfile.write("\n")
-        print("JSON sidecar was updated: {}".format(fname_json))
+        json_dict['GeneratedBy'].append({'Author': name_rater,
+                                         'Note': 'Manually corrected',
+                                         'Date': time.strftime('%Y-%m-%d %H:%M:%S')})
+    # If the was not modified, add "Note": ""Visually verified"" to the JSON sidecar
+    else:
+        json_dict['GeneratedBy'].append({'Author': name_rater,
+                                         'Note': 'Visually verified',
+                                         'Date': time.strftime('%Y-%m-%d %H:%M:%S')})
+
+    # Write the data to the JSON file
+    with open(fname_json, 'w') as outfile:  # w to overwrite the file
+        json.dump(json_dict, outfile, indent=4)
+        # Add last newline
+        outfile.write("\n")
+    print("JSON sidecar was updated: {}".format(fname_json))
 
 
 def ask_if_modify(fname_out, fname_label, do_labeling_always=False):

--- a/tests/test_create_json.py
+++ b/tests/test_create_json.py
@@ -26,7 +26,7 @@ def test_create_json_modified_true(tmp_path):
 
     # Check that the JSON file was created and contains the expected metadata
     expected_metadata = {'SpatialReference': 'orig',
-                         'GeneratedBy': [{'Name': 'Manually corrected',
+                         'GeneratedBy': [{'Name': 'Manual',
                                           'Author': "Test Rater",
                                           'Date': time.strftime('%Y-%m-%d %H:%M:%S')}]}
     json_file = tmp_path / fname_label.replace(".nii.gz", ".json")
@@ -74,7 +74,7 @@ def test_update_json_modified_true(tmp_path):
     json_file = tmp_path / fname_label.replace(".nii.gz", ".json")
     with open(str(json_file), "w") as f:
         json.dump({'SpatialReference': 'orig',
-                        'GeneratedBy': [{'Name': 'Manually corrected',
+                        'GeneratedBy': [{'Name': 'Manual',
                                          'Author': "Test Rater 1",
                                          'Date': "2023-01-01 00:00:00"}]}, f)
 
@@ -83,10 +83,10 @@ def test_update_json_modified_true(tmp_path):
 
     # Check that the JSON file was created and contains the expected metadata
     expected_metadata = {'SpatialReference': 'orig',
-                         'GeneratedBy': [{'Name': 'Manually corrected',
+                         'GeneratedBy': [{'Name': 'Manual',
                                           'Author': "Test Rater 1",
                                           'Date': "2023-01-01 00:00:00"},
-                                         {'Name': 'Manually corrected',
+                                         {'Name': 'Manual',
                                           'Author': "Test Rater 2",
                                           'Date': time.strftime('%Y-%m-%d %H:%M:%S')}]}
     json_file = tmp_path / fname_label.replace(".nii.gz", ".json")
@@ -109,7 +109,7 @@ def test_update_json_modified_false(tmp_path):
     json_file = tmp_path / fname_label.replace(".nii.gz", ".json")
     with open(str(json_file), "w") as f:
         json.dump({'SpatialReference': 'orig',
-                   'GeneratedBy': [{'Name': 'Manually corrected',
+                   'GeneratedBy': [{'Name': 'Manual',
                                     'Author': "Test Rater 1",
                                     'Date': "2023-01-01 00:00:00"}]}, f)
 
@@ -118,7 +118,7 @@ def test_update_json_modified_false(tmp_path):
 
     # Check that the JSON file was created and contains the expected metadata
     expected_metadata = {'SpatialReference': 'orig',
-                         'GeneratedBy': [{'Name': 'Manually corrected',
+                         'GeneratedBy': [{'Name': 'Manual',
                                           'Author': "Test Rater 1",
                                           'Date': "2023-01-01 00:00:00"},
                                          {'Name': 'Visually verified',

--- a/tests/test_create_json.py
+++ b/tests/test_create_json.py
@@ -11,10 +11,9 @@ import json
 from manual_correction import update_json
 
 
-def test_create_json_modified_true(tmp_path):
+def test_create_json(tmp_path):
     """
-    Test that the function update_json() creates a JSON file with the expected metadata if modified=True, i.e., the
-    label was manually corrected.
+    Test that the function update_json() creates a JSON file with the expected metadata
     """
     # Create a temporary file for testing
     fname_label = "sub-001_ses-01_T1w_seg-manual.nii.gz"
@@ -22,7 +21,7 @@ def test_create_json_modified_true(tmp_path):
     nifti_file.touch()
 
     # Call the function with modified=True
-    update_json(str(nifti_file), "Test Rater", modified=True)
+    update_json(str(nifti_file), "Test Rater")
 
     # Check that the JSON file was created and contains the expected metadata
     expected_metadata = {'SpatialReference': 'orig',
@@ -36,35 +35,9 @@ def test_create_json_modified_true(tmp_path):
     assert metadata == expected_metadata
 
 
-def test_create_json_modified_false(tmp_path):
+def test_update_json(tmp_path):
     """
-    Test that the function update_json() creates a JSON file with the expected metadata if modified=False, i.e., the
-    label was only visually inspected but not modified.
-    """
-    # Create a temporary file for testing
-    fname_label = "sub-001_ses-01_T1w_seg-manual.nii.gz"
-    nifti_file = tmp_path / fname_label
-    nifti_file.touch()
-
-    # Call the function with modified=True
-    update_json(str(nifti_file), "Test Rater", modified=False)
-
-    # Check that the JSON file was created and contains the expected metadata
-    expected_metadata = {'SpatialReference': 'orig',
-                         'GeneratedBy': [{'Name': 'Visually verified',
-                                          'Author': "Test Rater",
-                                          'Date': time.strftime('%Y-%m-%d %H:%M:%S')}]}
-    json_file = tmp_path / fname_label.replace(".nii.gz", ".json")
-    assert json_file.exists()
-    with open(str(json_file), "r") as f:
-        metadata = json.load(f)
-    assert metadata == expected_metadata
-
-
-def test_update_json_modified_true(tmp_path):
-    """
-    Test that the function update_json() updates (appends to) the JSON file with the expected metadata if
-    modified=True, i.e., the label was manually corrected.
+    Test that the function update_json() updates (appends to) the JSON file with the expected metadata.
     """
     # Create a temporary file for testing
     fname_label = "sub-001_ses-01_T1w_seg-manual.nii.gz"
@@ -79,7 +52,7 @@ def test_update_json_modified_true(tmp_path):
                                          'Date': "2023-01-01 00:00:00"}]}, f)
 
     # Call the function with modified=True
-    update_json(str(nifti_file), "Test Rater 2", modified=True)
+    update_json(str(nifti_file), "Test Rater 2")
 
     # Check that the JSON file was created and contains the expected metadata
     expected_metadata = {'SpatialReference': 'orig',
@@ -87,41 +60,6 @@ def test_update_json_modified_true(tmp_path):
                                           'Author': "Test Rater 1",
                                           'Date': "2023-01-01 00:00:00"},
                                          {'Name': 'Manual',
-                                          'Author': "Test Rater 2",
-                                          'Date': time.strftime('%Y-%m-%d %H:%M:%S')}]}
-    json_file = tmp_path / fname_label.replace(".nii.gz", ".json")
-    assert json_file.exists()
-    with open(str(json_file), "r") as f:
-        metadata = json.load(f)
-    assert metadata == expected_metadata
-
-
-def test_update_json_modified_false(tmp_path):
-    """
-    Test that the function update_json() updates (appends to) the JSON file with the expected metadata if
-    modified=False, i.e., the label was only visually inspected but not modified.
-    """
-    # Create a temporary file for testing
-    fname_label = "sub-001_ses-01_T1w_seg-manual.nii.gz"
-    nifti_file = tmp_path / fname_label
-    nifti_file.touch()
-    # Create JSON file with some metadata
-    json_file = tmp_path / fname_label.replace(".nii.gz", ".json")
-    with open(str(json_file), "w") as f:
-        json.dump({'SpatialReference': 'orig',
-                   'GeneratedBy': [{'Name': 'Manual',
-                                    'Author': "Test Rater 1",
-                                    'Date': "2023-01-01 00:00:00"}]}, f)
-
-    # Call the function with modified=True
-    update_json(str(nifti_file), "Test Rater 2", modified=False)
-
-    # Check that the JSON file was created and contains the expected metadata
-    expected_metadata = {'SpatialReference': 'orig',
-                         'GeneratedBy': [{'Name': 'Manual',
-                                          'Author': "Test Rater 1",
-                                          'Date': "2023-01-01 00:00:00"},
-                                         {'Name': 'Visually verified',
                                           'Author': "Test Rater 2",
                                           'Date': time.strftime('%Y-%m-%d %H:%M:%S')}]}
     json_file = tmp_path / fname_label.replace(".nii.gz", ".json")

--- a/tests/test_create_json.py
+++ b/tests/test_create_json.py
@@ -11,9 +11,10 @@ import json
 from manual_correction import update_json
 
 
-def test_create_json(tmp_path):
+def test_create_json_modified_true(tmp_path):
     """
-    Test that the function update_json() creates a JSON file with the expected metadata if modified=True.
+    Test that the function update_json() creates a JSON file with the expected metadata if modified=True, i.e., the
+    label was manually corrected.
     """
     # Create a temporary file for testing
     fname_label = "sub-001_ses-01_T1w_seg-manual.nii.gz"
@@ -24,7 +25,9 @@ def test_create_json(tmp_path):
     update_json(str(nifti_file), "Test Rater", modified=True)
 
     # Check that the JSON file was created and contains the expected metadata
-    expected_metadata = {'GeneratedBy': [{'Author': "Test Rater", 'Date': time.strftime('%Y-%m-%d %H:%M:%S')}]}
+    expected_metadata = {'GeneratedBy': [{'Author': "Test Rater",
+                                          'Note': 'Manually corrected',
+                                          'Date': time.strftime('%Y-%m-%d %H:%M:%S')}]}
     json_file = tmp_path / fname_label.replace(".nii.gz", ".json")
     assert json_file.exists()
     with open(str(json_file), "r") as f:
@@ -32,9 +35,34 @@ def test_create_json(tmp_path):
     assert metadata == expected_metadata
 
 
-def test_update_json(tmp_path):
+def test_create_json_modified_false(tmp_path):
     """
-    Test that the function update_json() updates (appends to) the JSON file with the expected metadata if modified=True.
+    Test that the function update_json() creates a JSON file with the expected metadata if modified=False, i.e., the
+    label was only visually inspected but not modified.
+    """
+    # Create a temporary file for testing
+    fname_label = "sub-001_ses-01_T1w_seg-manual.nii.gz"
+    nifti_file = tmp_path / fname_label
+    nifti_file.touch()
+
+    # Call the function with modified=True
+    update_json(str(nifti_file), "Test Rater", modified=False)
+
+    # Check that the JSON file was created and contains the expected metadata
+    expected_metadata = {'GeneratedBy': [{'Author': "Test Rater",
+                                          'Note': 'Visually verified',
+                                          'Date': time.strftime('%Y-%m-%d %H:%M:%S')}]}
+    json_file = tmp_path / fname_label.replace(".nii.gz", ".json")
+    assert json_file.exists()
+    with open(str(json_file), "r") as f:
+        metadata = json.load(f)
+    assert metadata == expected_metadata
+
+
+def test_update_json_modified_true(tmp_path):
+    """
+    Test that the function update_json() updates (appends to) the JSON file with the expected metadata if
+    modified=True, i.e., the label was manually corrected.
     """
     # Create a temporary file for testing
     fname_label = "sub-001_ses-01_T1w_seg-manual.nii.gz"
@@ -43,14 +71,53 @@ def test_update_json(tmp_path):
     # Create JSON file with some metadata
     json_file = tmp_path / fname_label.replace(".nii.gz", ".json")
     with open(str(json_file), "w") as f:
-        json.dump({'GeneratedBy': [{'Author': "Test Rater 1", 'Date': "2023-01-01 00:00:00"}]}, f)
+        json.dump({'GeneratedBy': [{'Author': "Test Rater 1",
+                                    'Note': 'Manually corrected',
+                                    'Date': "2023-01-01 00:00:00"}]}, f)
 
     # Call the function with modified=True
     update_json(str(nifti_file), "Test Rater 2", modified=True)
 
     # Check that the JSON file was created and contains the expected metadata
-    expected_metadata = {'GeneratedBy': [{'Author': "Test Rater 1", 'Date': "2023-01-01 00:00:00"},
-                                         {'Author': "Test Rater 2", 'Date': time.strftime('%Y-%m-%d %H:%M:%S')}]}
+    expected_metadata = {'GeneratedBy': [{'Author': "Test Rater 1",
+                                          'Note': 'Manually corrected',
+                                          'Date': "2023-01-01 00:00:00"},
+                                         {'Author': "Test Rater 2",
+                                          'Note': 'Manually corrected',
+                                          'Date': time.strftime('%Y-%m-%d %H:%M:%S')}]}
+    json_file = tmp_path / fname_label.replace(".nii.gz", ".json")
+    assert json_file.exists()
+    with open(str(json_file), "r") as f:
+        metadata = json.load(f)
+    assert metadata == expected_metadata
+
+
+def test_update_json_modified_false(tmp_path):
+    """
+    Test that the function update_json() updates (appends to) the JSON file with the expected metadata if
+    modified=False, i.e., the label was only visually inspected but not modified.
+    """
+    # Create a temporary file for testing
+    fname_label = "sub-001_ses-01_T1w_seg-manual.nii.gz"
+    nifti_file = tmp_path / fname_label
+    nifti_file.touch()
+    # Create JSON file with some metadata
+    json_file = tmp_path / fname_label.replace(".nii.gz", ".json")
+    with open(str(json_file), "w") as f:
+        json.dump({'GeneratedBy': [{'Author': "Test Rater 1",
+                                    'Note': 'Manually corrected',
+                                    'Date': "2023-01-01 00:00:00"}]}, f)
+
+    # Call the function with modified=True
+    update_json(str(nifti_file), "Test Rater 2", modified=False)
+
+    # Check that the JSON file was created and contains the expected metadata
+    expected_metadata = {'GeneratedBy': [{'Author': "Test Rater 1",
+                                          'Note': 'Manually corrected',
+                                          'Date': "2023-01-01 00:00:00"},
+                                         {'Author': "Test Rater 2",
+                                          'Note': 'Visually verified',
+                                          'Date': time.strftime('%Y-%m-%d %H:%M:%S')}]}
     json_file = tmp_path / fname_label.replace(".nii.gz", ".json")
     assert json_file.exists()
     with open(str(json_file), "r") as f:

--- a/tests/test_create_json.py
+++ b/tests/test_create_json.py
@@ -25,8 +25,9 @@ def test_create_json_modified_true(tmp_path):
     update_json(str(nifti_file), "Test Rater", modified=True)
 
     # Check that the JSON file was created and contains the expected metadata
-    expected_metadata = {'GeneratedBy': [{'Author': "Test Rater",
-                                          'Note': 'Manually corrected',
+    expected_metadata = {'SpatialReference': 'orig',
+                         'GeneratedBy': [{'Name': 'Manually corrected',
+                                          'Author': "Test Rater",
                                           'Date': time.strftime('%Y-%m-%d %H:%M:%S')}]}
     json_file = tmp_path / fname_label.replace(".nii.gz", ".json")
     assert json_file.exists()
@@ -49,8 +50,9 @@ def test_create_json_modified_false(tmp_path):
     update_json(str(nifti_file), "Test Rater", modified=False)
 
     # Check that the JSON file was created and contains the expected metadata
-    expected_metadata = {'GeneratedBy': [{'Author': "Test Rater",
-                                          'Note': 'Visually verified',
+    expected_metadata = {'SpatialReference': 'orig',
+                         'GeneratedBy': [{'Name': 'Visually verified',
+                                          'Author': "Test Rater",
                                           'Date': time.strftime('%Y-%m-%d %H:%M:%S')}]}
     json_file = tmp_path / fname_label.replace(".nii.gz", ".json")
     assert json_file.exists()
@@ -71,19 +73,21 @@ def test_update_json_modified_true(tmp_path):
     # Create JSON file with some metadata
     json_file = tmp_path / fname_label.replace(".nii.gz", ".json")
     with open(str(json_file), "w") as f:
-        json.dump({'GeneratedBy': [{'Author': "Test Rater 1",
-                                    'Note': 'Manually corrected',
-                                    'Date': "2023-01-01 00:00:00"}]}, f)
+        json.dump({'SpatialReference': 'orig',
+                        'GeneratedBy': [{'Name': 'Manually corrected',
+                                         'Author': "Test Rater 1",
+                                         'Date': "2023-01-01 00:00:00"}]}, f)
 
     # Call the function with modified=True
     update_json(str(nifti_file), "Test Rater 2", modified=True)
 
     # Check that the JSON file was created and contains the expected metadata
-    expected_metadata = {'GeneratedBy': [{'Author': "Test Rater 1",
-                                          'Note': 'Manually corrected',
+    expected_metadata = {'SpatialReference': 'orig',
+                         'GeneratedBy': [{'Name': 'Manually corrected',
+                                          'Author': "Test Rater 1",
                                           'Date': "2023-01-01 00:00:00"},
-                                         {'Author': "Test Rater 2",
-                                          'Note': 'Manually corrected',
+                                         {'Name': 'Manually corrected',
+                                          'Author': "Test Rater 2",
                                           'Date': time.strftime('%Y-%m-%d %H:%M:%S')}]}
     json_file = tmp_path / fname_label.replace(".nii.gz", ".json")
     assert json_file.exists()
@@ -104,19 +108,21 @@ def test_update_json_modified_false(tmp_path):
     # Create JSON file with some metadata
     json_file = tmp_path / fname_label.replace(".nii.gz", ".json")
     with open(str(json_file), "w") as f:
-        json.dump({'GeneratedBy': [{'Author': "Test Rater 1",
-                                    'Note': 'Manually corrected',
+        json.dump({'SpatialReference': 'orig',
+                   'GeneratedBy': [{'Name': 'Manually corrected',
+                                    'Author': "Test Rater 1",
                                     'Date': "2023-01-01 00:00:00"}]}, f)
 
     # Call the function with modified=True
     update_json(str(nifti_file), "Test Rater 2", modified=False)
 
     # Check that the JSON file was created and contains the expected metadata
-    expected_metadata = {'GeneratedBy': [{'Author': "Test Rater 1",
-                                          'Note': 'Manually corrected',
+    expected_metadata = {'SpatialReference': 'orig',
+                         'GeneratedBy': [{'Name': 'Manually corrected',
+                                          'Author': "Test Rater 1",
                                           'Date': "2023-01-01 00:00:00"},
-                                         {'Author': "Test Rater 2",
-                                          'Note': 'Visually verified',
+                                         {'Name': 'Visually verified',
+                                          'Author': "Test Rater 2",
                                           'Date': time.strftime('%Y-%m-%d %H:%M:%S')}]}
     json_file = tmp_path / fname_label.replace(".nii.gz", ".json")
     assert json_file.exists()


### PR DESCRIPTION
Updated description based on https://github.com/spinalcordtoolbox/manual-correction/pull/76#issuecomment-1939082475:

This PR adds new key-value pairs `SpatialReference': 'orig'` and `'Name': 'Manual'` into JSON sidecars:

```json
{
  "SpatialReference": "orig",
  "GeneratedBy": [
    {
      "Name": "Manual",
      "Author": "Test Rater",
      "Date": "2024-02-14"
    }
  ]
}
```

The PR also removes the `check_if_modified` function; for context see https://github.com/spinalcordtoolbox/manual-correction/pull/76#issuecomment-1939147742.

<details><summary>Original description</summary>

This PR proposes a new key-value pair `"Note"` to track if a label was only visually inspected or manually modified. To determine between these two scenarios, the already existing [`check_if_modified` function](https://github.com/spinalcordtoolbox/manual-correction/blob/7f20117654e6f1a602f144241171c46362ba89dc/manual_correction.py#L486) is levared.

## Scenario 1

If the label was only visually inspected but not modified, add `"Note": "Visually verified"` to the JSON file. Example:

```json
{
    "GeneratedBy": [
        {
            "Author": "Jan Valosek",
            "Note": "Visually verified",
            "Date": "2024-01-18 10:42:24"
        }
    ]
}
```

## Scenario 2

If the label was corrected, add `"Note": "Manually corrected"`:

```json
{
    "GeneratedBy": [
        {
            "Author": "Jan Valosek",
            "Note": "Manually corrected",
            "Date": "2024-01-18 10:42:24"
        }
    ]
}
```

Relevant discussion: https://github.com/ivadomed/canproco/issues/73#issuecomment-1911206492

</details>