### PR TITLE
Do not use date/time for the QC folder

### DIFF
--- a/manual_correction.py
+++ b/manual_correction.py
@@ -772,7 +772,7 @@ def main():
         print('')
 
     # Build QC report folder name
-    fname_qc = os.path.join(path_img, 'qc_corr_' + time.strftime('%Y%m%d%H%M%S'))
+    fname_qc = os.path.join(path_img, 'qc_corr')
     
     # Set overwrite variable to False
     do_labeling_always = False


### PR DESCRIPTION
This is a minor PR removing date/time for the QC folder. Now, even when the manual correction workflow is stopped and resumed, all QCs are saved under the save folder `qc_corr`.

Resolves: https://github.com/spinalcordtoolbox/manual-correction/issues/91