### PR TITLE
Include JSON metadata created by SCT

### DIFF
--- a/manual_correction.py
+++ b/manual_correction.py
@@ -906,6 +906,15 @@ def main():
                             if copy:
                                 shutil.copyfile(fname_label, fname_out)
                                 print(f'Copying: {fname_label} to {fname_out}')
+                                # If the label has a JSON sidecar, read its content
+                                # Context: SCT v6.4+ produces JSON sidecars for some outputs that track the provenance
+                                # of the function, models, etc.
+                                # Details: https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/4466
+                                # We want to include this information in the final JSON sidecar
+                                fname_label_json = fname_label.replace('.nii.gz', '.json')
+                                if os.path.isfile(fname_label_json):
+                                    # Read the JSON file to include the metadata in the final JSON sidecar
+                                    json_metadata = load_json(fname_label_json)
                             # Create empty mask in derivatives folder
                             elif create_empty_mask:
                                 utils.create_empty_mask(fname, fname_out)

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -245,9 +245,12 @@ def get_parser():
     )
     parser.add_argument(
         '-json-metadata', metavar="<file>", required=False,
-        help="R|A custom JSON file containing metadata to be added to the JSON sidecar of all corrected labels. "
+        help="R|A custom JSON file containing metadata to be added to the output JSON sidecar of all corrected labels. "
              "This flag is useful, for example, when a label was obtained automatically and you want to include this "
-             "information into the JSON sidecar. "
+             "information into the JSON sidecar. \n"
+             "NOTE: the script automatically checks whether the JSON file already exists (for example when "
+             "automatically created by SCT 6.4+). If so, the script will reuse its metadata. In such cases, you do not "
+             "need to use this flag.\n"
              "Below is an example JSON file:\n"
              + dedent(
              """

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -514,11 +514,11 @@ def correct_centerline(fname, fname_label, viewer='sct_get_centerline'):
         viewer_not_found(viewer)
 
 
-def load_custom_json(fname):
+def load_json(fname):
     """
-    Load custom JSON file.
-    :param fname: path to the custom JSON file.
-    :return: dictionary with the metadata to be added to the JSON sidecar.
+    Load existing JSON file. The content of the JSON file will be added to the JSON file produced by this script.
+    :param fname: path to the existing JSON file.
+    :return: dictionary with the metadata to be added to the output JSON sidecar.
     """
     if not os.path.isfile(fname):
         sys.exit("ERROR: The file {} does not exist.".format(fname))
@@ -794,7 +794,7 @@ def main():
             sys.exit("ERROR: No segmentation file found in {}.".format(args.path_label))
 
     # If a custom JSON file containing metadata was provided, load it, and verify that it is a valid JSON file
-    json_metadata = load_custom_json(args.json_metadata) if args.json_metadata else None
+    json_metadata = load_json(args.json_metadata) if args.json_metadata else None
 
     # Get name of expert rater (skip if -qc-only is true)
     if not args.qc_only:


### PR DESCRIPTION
## Description 

As SCT v6.4+ produces JSON sidecars for some outputs that track the provenance of the function, models, etc. (details: https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/4466), we want to include this information in the final JSON sidecar produced by `manual_correction.py`.  This PR implements this feature.

## How to test this PR

```console
cd ~/code/manual-correction
git fetch
git checkout jv/103_include_json_created_by_sct
```

```console
sct_download_data -d sct_course_data -o sct_course_data_2024
cd sct_course_data_2024/multi_subject
chmod +x process_data.sh
sct_run_batch -script process_data.sh -config config.yml -jobs 3
# Note: you can add `exit` to line 115 to run only the contrast-agnostic model on T2w to save time

$SCT_DIR/python/envs/venv_sct/bin/python ~/code/manual-correction/manual_correction.py -config qc_fail.yml -path-img output/data_processed/ -path-label output/data_processed -path-out data/derivatives/labels

cat data/derivatives/labels/sub-05/anat/sub-05_T2w_seg.json
```

```json
{
    "SpatialReference": "orig",
    "GeneratedBy": [
        {
            "GeneratedBy": [
                {
                    "Name": "spinalcordtoolbox: sct_deepseg -task seg_sc_contrast_agnostic -i sub-05_T2w.nii.gz -qc qc -qc-subject sub-05",
                    "Version": "git-master-64f55fdf022659db5d5c779f01c605d91ca7d052",
                    "CodeURL": "https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/64f55fdf022659db5d5c779f01c605d91ca7d052/spinalcordtoolbox/scripts/sct_deepseg.py",
                    "ModelURL": "https://github.com/sct-pipeline/contrast-agnostic-softseg-spinalcord/releases/download/v2.5/model_contrast-agnostic_20240930-1002.zip"
                }
            ]
        },
        {
            "Name": "Manual",
            "Author": "Jan Valosek",
            "Date": "2024-12-10 18:05:31"
        }
    ]
}
```

As you can see above, the output JSON sidecar under derivatives now includes information about the SCT model and the manual rater who made manual corrections.

---

Resolves: https://github.com/spinalcordtoolbox/manual-correction/issues/103
Relevant to: https://github.com/spinalcordtoolbox/manual-correction/pull/102