### PR TITLE
Set the default value for `-path-label` to match `-path-img`

### DIFF
--- a/manual_correction.py
+++ b/manual_correction.py
@@ -43,7 +43,8 @@ def get_parser():
         description='Manual correction of spinal cord segmentation, gray matter segmentation, MS and SCI lesion '
                     'segmentation, disc labels, compression labels, ponto-medullary junction (PMJ) label, and '
                     'centerline. '
-                    'Manually corrected files will be saved under derivatives/ folder (according to BIDS standard).',
+                    'Manually corrected files will be saved under derivatives/labels folder (according to BIDS '
+                    'standard) if not specified otherwise.',
         formatter_class=utils.SmartFormatter,
         prog=os.path.basename(__file__).strip('.py')
     )

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -107,9 +107,8 @@ def get_parser():
         metavar="<folder>",
         help=
         "R|Full path to the folder with labels (BIDS-compliant). "
-        "\nIf labels are located in the same folder as the images, provide the same path as '-path-img', for example "
-        "'output/data_processed'."
-        "\nIf not provided, '-path-img' + 'derivatives/labels' will be used. ",
+        "\nIf not provided, '-path-img' will be used (assuming that the labels are in the same folder as images). "
+        "\nIf your labels are already under 'derivatives/labels', provide the full path to this folder. ",
         default=''
     )
     parser.add_argument(
@@ -758,16 +757,13 @@ def main():
         'FILES_CENTERLINE': args.suffix_files_centerline    # e.g., _centerline or _label-centerline
     }
     path_img = utils.get_full_path(args.path_img)
-    
-    if args.path_label == '':
-        path_label = os.path.join(path_img, "derivatives/labels")
-    else:
-        path_label = utils.get_full_path(args.path_label)
-    
-    if args.path_out == '':
-        path_out = os.path.join(path_img, "derivatives/labels")
-    else:
-        path_out = utils.get_full_path(args.path_out)
+
+    # If labels are in the same folder as the images, set path_label to path_img
+    path_label = path_img if args.path_label == '' else utils.get_full_path(args.path_label)
+
+    # If not specified, output folder for corrected labels is derivatives/labels in the input folder
+    path_out = os.path.join(path_img, "derivatives/labels") if args.path_out == '' else utils.get_full_path(
+        args.path_out)
 
     # Print parsed arguments
     logging.info("-" * 100)

--- a/manual_correction.py
+++ b/manual_correction.py
@@ -768,9 +768,9 @@ def main():
     # Print parsed arguments
     logging.info("-" * 100)
     logging.info("Parsing of arguments:")
-    logging.info("  Input folder ('-path-img') .............. " + path_img)
-    logging.info("  Label folder ('-path-label') .............. " + path_label)
-    logging.info("  Output folder ('-path-out') ............. " + path_out)
+    logging.info("  Input folder ('-path-img'):     " + path_img)
+    logging.info("  Label folder ('-path-label'):   " + path_label)
+    logging.info("  Output folder ('-path-out'):    " + path_out)
     logging.info("-" * 100)
 
     # check that output folder exists or create it


### PR DESCRIPTION
## Description

This PR changes the default value for `-path-label` to match `-path-img`. Context: https://github.com/spinalcordtoolbox/manual-correction/issues/104

The change simplifies the `manual_correction.py` syntax as used for the SCT course to

```
manual_correction.py -config qc_fail.yml -path-img output/data_processed/ -path-out data/derivatives/labels
``` 

(i.e., we do not need to specify `-path-label` now, as it is automatically set to `-path-img`)

## How to test this PR

```bash
cd ~/code/manual-correction
git fetch
git checkout jv/104-set_path-label_to_path-img
```

```bash
sct_download_data -d sct_course_data -o sct_course_data_2024
cd sct_course_data_2024/multi_subject
chmod +x process_data.sh
sct_run_batch -script process_data.sh -config config.yml -jobs 3
# Note: you can add `exit` to line 115 to run only the contrast-agnostic model on T2w to save time

$SCT_DIR/python/envs/venv_sct/bin/python ~/code/manual-correction/manual_correction.py -config qc_fail.yml -path-img output/data_processed/ -path-out data/derivatives/labels
```

---

Resolves: https://github.com/spinalcordtoolbox/manual-correction/issues/104