### PR TITLE
Unfreeze package versions in `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-coloredlogs==15.0.1
-humanfriendly==10.0
-PyYAML==6.0
-numpy~=1.24.2
-nibabel~=5.0.1
-tqdm==4.65.0
-pytest==7.2.2
+coloredlogs
+humanfriendly
+PyYAML
+numpy
+nibabel
+tqdm
+pytest


### PR DESCRIPTION
There was a dependency error on my Mac with Python 3.13.5 with fixed package versions. As the repo uses only general packages, I think it's safe to unfreeze specific versions.

Resolves: https://github.com/spinalcordtoolbox/manual-correction/issues/111