### PR TITLE
Fix orientation extraction from `sct_image` output

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -346,12 +346,13 @@ def get_orientation(file_path):
         Returns:
         str: The parsed image orientation.
         """
-
         output_string = output_bytes.decode('utf-8')
-        lines = output_string.strip().split('\n')
-        # Get only the string containing the orientation, e.g., 'RPI'
-        orientation = lines[-2].strip()
-        return orientation
+        for line in output_string.strip().split('\n'):
+            line = line.strip()
+            # Orientation string is 3 uppercase letters, e.g., LPI, AIL
+            if len(line) == 3 and line.isupper():
+                return line
+        raise ValueError(f"Could not parse orientation from:\n{output_string}")
 
     # Note: we use bash command 'sct_image' to get the orientation instead of SCT's Image class because this would
     # introduce dependency on SCT conda environment

--- a/utils.py
+++ b/utils.py
@@ -350,7 +350,7 @@ def get_orientation(file_path):
         output_string = output_bytes.decode('utf-8')
         lines = output_string.strip().split('\n')
         # Get only the string containing the orientation, e.g., 'RPI'
-        orientation = lines[-1].strip()
+        orientation = lines[-2].strip()
         return orientation
 
     # Note: we use bash command 'sct_image' to get the orientation instead of SCT's Image class because this would


### PR DESCRIPTION
This PR fixes the failing CI for `test_get_orientation`:

![image](https://github.com/user-attachments/assets/5eec340d-f762-4639-8501-3d463d1421ab)


SCT now adds an extra line with total runtime at the end of its output. Example:

```
--
Spinal Cord Toolbox (git-jv/sct_process_segmentation_use_hog-2825761400b80fa7d556d24356f78e437c664496*)

sct_image -i /private/var/folders/v3/00vnhxcj5vg7d7mr7r4vl5sr0000gn/T/pytest-of-valosek/pytest-3/test_get_orientation0/BIDS/sub-001/ses-01/anat/sub-001_ses-01_T1w.nii.gz -getorient
--

LPI
Total runtime; 0.150 seconds.
```

We thus need to strip one extra line to get `LPI`.