### PR TITLE
 Track JSON sidecar label: actual modification vs visual check

### DIFF
--- a/manual_correction.py
+++ b/manual_correction.py
@@ -546,12 +546,13 @@ def load_json(fname):
         sys.exit("ERROR: The file {} is not a valid JSON file.".format(fname))
 
 
-def update_json(fname_nifti, name_rater, json_metadata):
+def update_json(fname_nifti, name_rater, json_metadata, modified=True):
     """
     Create/update JSON sidecar with meta information
     :param fname_nifti: str: File name of the nifti image to associate with the JSON sidecar
     :param name_rater: str: Name of the expert rater
     :param json_metadata: dict: Dictionary with the metadata to be added to the JSON sidecar
+    :param modified: bool: True if the label was actually modified (saved), False if it was only visually checked
     :return:
     """
     fname_json = fname_nifti.replace('.gz', '').replace('.nii', '.json')
@@ -584,8 +585,9 @@ def update_json(fname_nifti, name_rater, json_metadata):
             else:
                 json_dict['GeneratedBy'].append(json_metadata.copy())
 
-    # If the label was modified or just checked, add "Name": "Manual" to the JSON sidecar
-    json_dict['GeneratedBy'].append({'Name': 'Manual',
+    # If the label was modified, use 'Manual correction'; if only visually checked, use 'Visual check'
+    entry_name = 'Manual correction' if modified else 'Visual check'
+    json_dict['GeneratedBy'].append({'Name': entry_name,
                                      'Author': name_rater,
                                      'Date': time.strftime('%Y-%m-%d %H:%M:%S')})
 
@@ -939,24 +941,40 @@ def main():
                             elif create_empty_mask:
                                 utils.create_empty_mask(fname, fname_out)
 
+                            # Record modification time before opening the viewer to detect if the label was changed
+                            mtime_before = None
                             if task in ['FILES_SEG', 'FILES_GMSEG', 'FILES_ROOTLETS']:
                                 if not args.add_seg_only:
+                                    mtime_before = os.path.getmtime(fname_out) if os.path.isfile(fname_out) else None
                                     correct_segmentation(fname, fname_out, fname_other_contrast, args.viewer, param_fsleyes)
                             elif task == 'FILES_LESION':
+                                mtime_before = os.path.getmtime(fname_out) if os.path.isfile(fname_out) else None
                                 correct_segmentation(fname, fname_out, fname_other_contrast, args.viewer, param_fsleyes)
                             elif task == 'FILES_LABEL':
+                                mtime_before = os.path.getmtime(fname_out) if os.path.isfile(fname_out) else None
                                 correct_vertebral_labeling(fname, fname_out, args.label_disc_list)
                             elif task == 'FILES_COMPRESSION':
                                 # Note: be aware of possibility to create compression labels also using
                                 # 'sct_label_utils -create-viewer'
                                 # Context: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3984
+                                mtime_before = os.path.getmtime(fname_out) if os.path.isfile(fname_out) else None
                                 correct_segmentation(fname, fname_out, fname_other_contrast, 'fsleyes', param_fsleyes)
                             elif task == 'FILES_PMJ':
+                                mtime_before = os.path.getmtime(fname_out) if os.path.isfile(fname_out) else None
                                 correct_pmj_label(fname, fname_out)
                             elif task == 'FILES_CENTERLINE':
+                                mtime_before = os.path.getmtime(fname_out) if os.path.isfile(fname_out) else None
                                 correct_centerline(fname, fname_out)
                             else:
                                 sys.exit('Task not recognized from the YAML file: {}'.format(task))
+
+                            # Determine if the label was actually modified by comparing the file's modification time
+                            if task in ['FILES_SEG', 'FILES_GMSEG', 'FILES_ROOTLETS'] and args.add_seg_only:
+                                # add_seg_only skips the viewer, so the file is always considered modified
+                                label_modified = True
+                            else:
+                                mtime_after = os.path.getmtime(fname_out) if os.path.isfile(fname_out) else None
+                                label_modified = (mtime_before is None) or (mtime_after != mtime_before)
                             if args.denoise:
                                 # Remove the denoised file (we do not need it anymore)
                                 remove_denoised_file(fname)
@@ -965,10 +983,10 @@ def main():
                             if args.add_seg_only:
                                 # We use update_json because we are adding a new segmentation, and we want to create
                                 # a JSON file
-                                update_json(fname_out, name_rater, json_metadata)
+                                update_json(fname_out, name_rater, json_metadata, modified=label_modified)
                             # Generate QC report
                             else:
-                                update_json(fname_out, name_rater, json_metadata)
+                                update_json(fname_out, name_rater, json_metadata, modified=label_modified)
                                 # Generate QC report
                                 generate_qc(fname, fname_out, task, fname_qc, subject, args.config, args.qc_lesion_plane, suffix_dict)
 

--- a/tests/test_create_json.py
+++ b/tests/test_create_json.py
@@ -20,12 +20,36 @@ def test_create_json(tmp_path):
     nifti_file = tmp_path / fname_label
     nifti_file.touch()
 
-    # Call the function with modified=True
-    update_json(str(nifti_file), "Test Rater", json_metadata=None)
+    # Call the function with modified=True (label was actually corrected)
+    update_json(str(nifti_file), "Test Rater", json_metadata=None, modified=True)
 
     # Check that the JSON file was created and contains the expected metadata
     expected_metadata = {'SpatialReference': 'orig',
-                         'GeneratedBy': [{'Name': 'Manual',
+                         'GeneratedBy': [{'Name': 'Manual correction',
+                                          'Author': "Test Rater",
+                                          'Date': time.strftime('%Y-%m-%d %H:%M:%S')}]}
+    json_file = tmp_path / fname_label.replace(".nii.gz", ".json")
+    assert json_file.exists()
+    with open(str(json_file), "r") as f:
+        metadata = json.load(f)
+    assert metadata == expected_metadata
+
+
+def test_create_json_visual_check(tmp_path):
+    """
+    Test that the function update_json() creates a JSON file with 'Visual check' when modified=False
+    """
+    # Create a temporary file for testing
+    fname_label = "sub-001_ses-01_T1w_seg-manual.nii.gz"
+    nifti_file = tmp_path / fname_label
+    nifti_file.touch()
+
+    # Call the function with modified=False (label was only visually checked, not modified)
+    update_json(str(nifti_file), "Test Rater", json_metadata=None, modified=False)
+
+    # Check that the JSON file was created and contains 'Visual check' as the Name
+    expected_metadata = {'SpatialReference': 'orig',
+                         'GeneratedBy': [{'Name': 'Visual check',
                                           'Author': "Test Rater",
                                           'Date': time.strftime('%Y-%m-%d %H:%M:%S')}]}
     json_file = tmp_path / fname_label.replace(".nii.gz", ".json")
@@ -49,15 +73,15 @@ def test_create_json_custom_metadata(tmp_path):
                      'Author': "SCT v6.2",
                      'Date': "2024-02-21 00:00:00"}
 
-    # Call the function with modified=True
-    update_json(str(nifti_file), "Test Rater", json_metadata=custom_metadata)
+    # Call the function with modified=True (label was actually corrected)
+    update_json(str(nifti_file), "Test Rater", json_metadata=custom_metadata, modified=True)
 
     # Check that the JSON file was created and contains the expected metadata
     expected_metadata = {'SpatialReference': 'orig',
                          'GeneratedBy': [{'Name': 'sct_deepseg_sc',
                                           'Author': "SCT v6.2",
                                           'Date': "2024-02-21 00:00:00"},
-                                         {'Name': 'Manual',
+                                         {'Name': 'Manual correction',
                                           'Author': "Test Rater",
                                           'Date': time.strftime('%Y-%m-%d %H:%M:%S')}]}
     json_file = tmp_path / fname_label.replace(".nii.gz", ".json")
@@ -79,19 +103,19 @@ def test_update_json(tmp_path):
     json_file = tmp_path / fname_label.replace(".nii.gz", ".json")
     with open(str(json_file), "w") as f:
         json.dump({'SpatialReference': 'orig',
-                        'GeneratedBy': [{'Name': 'Manual',
+                        'GeneratedBy': [{'Name': 'Manual correction',
                                          'Author': "Test Rater 1",
                                          'Date': "2023-01-01 00:00:00"}]}, f)
 
-    # Call the function with modified=True
-    update_json(str(nifti_file), "Test Rater 2", json_metadata=None)
+    # Call the function with modified=True (label was actually corrected)
+    update_json(str(nifti_file), "Test Rater 2", json_metadata=None, modified=True)
 
     # Check that the JSON file was created and contains the expected metadata
     expected_metadata = {'SpatialReference': 'orig',
-                         'GeneratedBy': [{'Name': 'Manual',
+                         'GeneratedBy': [{'Name': 'Manual correction',
                                           'Author': "Test Rater 1",
                                           'Date': "2023-01-01 00:00:00"},
-                                         {'Name': 'Manual',
+                                         {'Name': 'Manual correction',
                                           'Author': "Test Rater 2",
                                           'Date': time.strftime('%Y-%m-%d %H:%M:%S')}]}
     json_file = tmp_path / fname_label.replace(".nii.gz", ".json")
@@ -117,8 +141,8 @@ def test_update_json_generated_by_sct(tmp_path):
         'CodeURL': 'https://github.com/spinalcordtoolbox/sct_deepseg.py',
         'ModelURL': 'https://github.com/sct-pipeline/model.zip'}]}
 
-    # Call the function with modified=True
-    update_json(str(nifti_file), "Test Rater 1", json_metadata=custom_metadata)
+    # Call the function with modified=True (label was actually corrected)
+    update_json(str(nifti_file), "Test Rater 1", json_metadata=custom_metadata, modified=True)
 
     # Check that the JSON file was created and contains the expected metadata
     expected_metadata = {'SpatialReference': 'orig',
@@ -127,7 +151,7 @@ def test_update_json_generated_by_sct(tmp_path):
                              'Version': '6.5',
                              'CodeURL': 'https://github.com/spinalcordtoolbox/sct_deepseg.py',
                              'ModelURL': 'https://github.com/sct-pipeline/model.zip'},
-                             {'Name': 'Manual',
+                             {'Name': 'Manual correction',
                               'Author': "Test Rater 1",
                               'Date': time.strftime('%Y-%m-%d %H:%M:%S')}]}
     json_file = tmp_path / fname_label.replace(".nii.gz", ".json")
@@ -135,3 +159,4 @@ def test_update_json_generated_by_sct(tmp_path):
     with open(str(json_file), "r") as f:
         metadata = json.load(f)
     assert metadata == expected_metadata
+


### PR DESCRIPTION
This PR enhances the way manual corrections and visual checks are tracked and recorded in the JSON sidecars. The main change is the ability to distinguish between when a label was actually modified (`Manual correction`) versus when it was only visually checked (`Visual check`). I found this useful when reviewing lesions.

**Enhancements to JSON metadata tracking:**

* The `update_json` function now takes a `modified` parameter to indicate if the label was actually changed or just visually checked, and records "Manual correction" or "Visual check" accordingly in the `GeneratedBy` field of the JSON.
* The script now detects whether a label was modified by comparing the file's modification time before and after the editing session, and passes this information to `update_json`.

`Manual correction`:
```json
{
    "GeneratedBy": [
        ...
        {
            "Name": "Manual correction",
            "Author": "Jan Valosek",
            "Date": "2026-03-18 16:48:25"
        }
    ],
    "SpatialReference": "orig"
}
```

`Visual check`:
```json
{
    "GeneratedBy": [
        ...
        {
            "Name": "Visual check",
            "Author": "Jan Valosek",
            "Date": "2026-03-18 16:44:49"
        }
    ],
    "SpatialReference": "orig"
}
```