### PR TITLE
Add script to extract input filenames from SCT's `qc_report.json` for a given QC emoji

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,4 @@ jobs:
 
       - name: Run tests with pytest
         run: |
-          python -m pytest -v tests/test_utils.py
-          python -m pytest -v tests/test_ask_if_modify.py
-          python -m pytest -v tests/test_create_json.py
-          python -m pytest -v tests/test_get_qc_input_files.py
+          python -m pytest -v tests/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,4 @@ jobs:
           python -m pytest -v tests/test_utils.py
           python -m pytest -v tests/test_ask_if_modify.py
           python -m pytest -v tests/test_create_json.py
+          python -m pytest -v tests/test_get_qc_input_files.py

--- a/get_qc_input_files.py
+++ b/get_qc_input_files.py
@@ -1,24 +1,37 @@
 #!/usr/bin/env python3
 """
-Extract input filenames from SCT's qc_report.json for a given QC emoji.
+Extract file names from SCT's qc_report.json for a given QC emoji.
+
+By default prints each matching entry's ``inputFile`` (the source image, e.g.
+the T2w). Pass ``--label`` to instead print the label file being QC'd, parsed
+from the ``-s`` argument of the entry's ``cmdline``. This distinguishes sessions
+that have several QC entries (one per label: seg, canal, disc, pmj, ...).
 
 Usage:
   python get_qc_input_files.py --qc "✅" qc_report.json
-  python get_qc_input_files.py --qc "⚠️" --full-path qc_report.json
+  python get_qc_input_files.py --qc "✅" --label qc_report.json
+  python get_qc_input_files.py --qc "⚠️" --label --full-path qc_report.json
 
 Example output:
 $ python ~/code/manual-correction/get_qc_input_files.py --qc ✅ qc_report.json
     sub-001_T2w.nii.gz
     sub-004_T2w.nii.gz
+$ python ~/code/manual-correction/get_qc_input_files.py --qc ✅ --label qc_report.json
+    sub-001_T2w_seg.nii.gz
+    sub-001_T2w_pmj.nii.gz
 """
 
 import argparse
 import json
+import re
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 
 EMOJI_CHOICES: List[str] = ["✅", "⚠️", "❌"]
+
+# Matches the label/segmentation passed to `-s` in an entry's cmdline.
+SEG_ARG_RE = re.compile(r"-s\s+(\S+\.nii\.gz)")
 
 
 def load_qc_report(path: Path) -> Dict[str, Any]:
@@ -36,6 +49,19 @@ def load_qc_report(path: Path) -> Dict[str, Any]:
     """
     with path.open("r", encoding="utf-8") as f:
         return json.load(f)
+
+
+def extract_label_file(cmdline: str) -> Optional[str]:
+    """Extract the label file (the ``-s`` argument) from an entry's cmdline.
+
+    Args:
+        cmdline: The ``cmdline`` string of a QC report entry.
+
+    Returns:
+        The path passed to ``-s``, or ``None`` if none is found.
+    """
+    match = SEG_ARG_RE.search(cmdline or "")
+    return match.group(1) if match else None
 
 
 def filter_input_files(
@@ -70,6 +96,39 @@ def filter_input_files(
     return results
 
 
+def filter_label_files(
+    report: Dict[str, Any], emoji: str, full_path: bool = False
+) -> List[str]:
+    """Filter label files (cmdline ``-s`` argument) by QC emoji.
+
+    Unlike :func:`filter_input_files`, this returns the specific label being
+    QC'd, so a session with several entries (seg, canal, disc, pmj, ...) is
+    distinguished per label.
+
+    Args:
+        report: Parsed QC report dictionary.
+        emoji: QC emoji to filter by (e.g. "✅", "⚠️", "❌").
+        full_path: If True, return the absolute ``-s`` path, otherwise only the
+            file name.
+
+    Returns:
+        List of label file strings (or full paths) matching the given emoji.
+    """
+    datasets = report.get("datasets", [])
+    results: List[str] = []
+
+    for item in datasets:
+        if item.get("qc") != emoji:
+            continue
+        label_file = extract_label_file(item.get("cmdline", ""))
+        if not label_file:
+            continue
+
+        results.append(label_file if full_path else Path(label_file).name)
+
+    return results
+
+
 def parse_args() -> argparse.Namespace:
     """Parse command-line arguments.
 
@@ -77,7 +136,7 @@ def parse_args() -> argparse.Namespace:
         Parsed arguments namespace.
     """
     parser = argparse.ArgumentParser(
-        description="Get inputFiles for a given QC emoji from qc_report.json."
+        description="Get files for a given QC emoji from qc_report.json."
     )
     parser.add_argument(
         "qc_report",
@@ -92,9 +151,17 @@ def parse_args() -> argparse.Namespace:
         help="QC emoji to filter by (✅, ⚠️, or ❌).",
     )
     parser.add_argument(
+        "--label",
+        "-l",
+        action="store_true",
+        help="Print the label file being QC'd (parsed from the cmdline `-s` "
+        "argument) instead of the source inputFile. Gives per-label detail "
+        "when a session has several QC entries.",
+    )
+    parser.add_argument(
         "--full-path",
         action="store_true",
-        help="Print full paths (path/inputFile) instead of only inputFile.",
+        help="Print full paths instead of only the file name.",
     )
     return parser.parse_args()
 
@@ -103,15 +170,18 @@ def main() -> None:
     """Entry point for the script."""
     args = parse_args()
     report = load_qc_report(args.qc_report)
-    input_files = filter_input_files(report, args.qc, full_path=args.full_path)
 
-    for f in sorted(input_files):
+    if args.label:
+        files = filter_label_files(report, args.qc, full_path=args.full_path)
+    else:
+        files = filter_input_files(report, args.qc, full_path=args.full_path)
+
+    for f in sorted(files):
         print(f)
 
     # Print total count
-    print(f"Total files with QC '{args.qc}': {len(input_files)}")
+    print(f"Total files with QC '{args.qc}': {len(files)}")
 
 
 if __name__ == "__main__":
     main()
-

--- a/get_qc_input_files.py
+++ b/get_qc_input_files.py
@@ -105,7 +105,7 @@ def main() -> None:
     report = load_qc_report(args.qc_report)
     input_files = filter_input_files(report, args.qc, full_path=args.full_path)
 
-    for f in input_files:
+    for f in sorted(input_files):
         print(f)
 
     # Print total count

--- a/get_qc_input_files.py
+++ b/get_qc_input_files.py
@@ -1,10 +1,17 @@
 #!/usr/bin/env python3
 """
-Extract file names from SCT's qc_report.json for a given QC status.
+Extract file names from SCT's qc_report.json for a given QC status and/or rank.
+
+Entries can be filtered by QC status (``--qc``) and/or by rank (``--rank``); at
+least one of the two is required, and when both are given an entry must match
+both.
 
 The QC status is passed as a keyword (``pass``, ``warn``, or ``fail``) rather
 than the raw emoji, which interacts awkwardly with some shells (e.g. zsh on
 macOS). The keyword is mapped internally to the emoji stored in the report.
+
+The rank is the integer 0-9 set with the number keys in the QC report viewer,
+stored in each entry's ``rank`` field (independent of the QC status).
 
 By default prints each matching entry's ``inputFile`` (the source image, e.g.
 the T2w). Pass ``--label`` to instead print the label file being QC'd, parsed
@@ -13,7 +20,8 @@ that have several QC entries (one per label: seg, canal, disc, pmj, ...).
 
 Usage:
   python get_qc_input_files.py --qc pass qc_report.json
-  python get_qc_input_files.py --qc pass --label qc_report.json
+  python get_qc_input_files.py --rank 2 qc_report.json
+  python get_qc_input_files.py --qc pass --rank 2 qc_report.json
   python get_qc_input_files.py --qc warn --label --full-path qc_report.json
 
 Example output:
@@ -75,24 +83,48 @@ def extract_label_file(cmdline: str) -> Optional[str]:
     return match.group(1) if match else None
 
 
+def entry_matches(
+    item: Dict[str, Any], emoji: Optional[str], rank: Optional[int]
+) -> bool:
+    """Check whether a QC report entry matches the requested filters.
+
+    Args:
+        item: A single QC report entry.
+        emoji: QC emoji to match (e.g. "✅"), or None to not filter by QC.
+        rank: Rank integer to match, or None to not filter by rank.
+
+    Returns:
+        True if the entry matches all of the provided (non-None) filters.
+    """
+    if emoji is not None and item.get("qc") != emoji:
+        return False
+    if rank is not None and item.get("rank") != rank:
+        return False
+    return True
+
+
 def filter_input_files(
-    report: Dict[str, Any], emoji: str, full_path: bool = False
+    report: Dict[str, Any],
+    emoji: Optional[str],
+    rank: Optional[int],
+    full_path: bool = False,
 ) -> List[str]:
-    """Filter inputFile entries by QC emoji.
+    """Filter inputFile entries by QC emoji and/or rank.
 
     Args:
         report: Parsed QC report dictionary.
-        emoji: QC emoji to filter by (e.g. "✅", "⚠️", "❌").
+        emoji: QC emoji to filter by (e.g. "✅", "⚠️", "❌"), or None.
+        rank: Rank integer (0-9) to filter by, or None.
         full_path: If True, return path/inputFile, otherwise only inputFile.
 
     Returns:
-        List of inputFile strings (or full paths) matching the given emoji.
+        List of inputFile strings (or full paths) matching the filters.
     """
     datasets = report.get("datasets", [])
     results: List[str] = []
 
     for item in datasets:
-        if item.get("qc") != emoji:
+        if not entry_matches(item, emoji, rank):
             continue
         input_file = item.get("inputFile")
         if not input_file:
@@ -108,9 +140,12 @@ def filter_input_files(
 
 
 def filter_label_files(
-    report: Dict[str, Any], emoji: str, full_path: bool = False
+    report: Dict[str, Any],
+    emoji: Optional[str],
+    rank: Optional[int],
+    full_path: bool = False,
 ) -> List[str]:
-    """Filter label files (cmdline ``-s`` argument) by QC emoji.
+    """Filter label files (cmdline ``-s`` argument) by QC emoji and/or rank.
 
     Unlike :func:`filter_input_files`, this returns the specific label being
     QC'd, so a session with several entries (seg, canal, disc, pmj, ...) is
@@ -118,18 +153,19 @@ def filter_label_files(
 
     Args:
         report: Parsed QC report dictionary.
-        emoji: QC emoji to filter by (e.g. "✅", "⚠️", "❌").
+        emoji: QC emoji to filter by (e.g. "✅", "⚠️", "❌"), or None.
+        rank: Rank integer (0-9) to filter by, or None.
         full_path: If True, return the absolute ``-s`` path, otherwise only the
             file name.
 
     Returns:
-        List of label file strings (or full paths) matching the given emoji.
+        List of label file strings (or full paths) matching the filters.
     """
     datasets = report.get("datasets", [])
     results: List[str] = []
 
     for item in datasets:
-        if item.get("qc") != emoji:
+        if not entry_matches(item, emoji, rank):
             continue
         label_file = extract_label_file(item.get("cmdline", ""))
         if not label_file:
@@ -147,7 +183,8 @@ def parse_args() -> argparse.Namespace:
         Parsed arguments namespace.
     """
     parser = argparse.ArgumentParser(
-        description="Get files for a given QC status from qc_report.json."
+        description="Get files for a given QC status and/or rank from "
+        "qc_report.json."
     )
     parser.add_argument(
         "qc_report",
@@ -157,9 +194,17 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--qc",
         "-q",
-        required=True,
         choices=list(QC_STATUS_TO_EMOJI),
         help="QC status to filter by: 'pass' (✅), 'warn' (⚠️), or 'fail' (❌).",
+    )
+    parser.add_argument(
+        "--rank",
+        "-r",
+        type=int,
+        choices=range(10),
+        metavar="{0-9}",
+        help="Rank (0-9) to filter by, as set with the number keys in the QC "
+        "report viewer.",
     )
     parser.add_argument(
         "--label",
@@ -174,7 +219,12 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Print full paths instead of only the file name.",
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+
+    if args.qc is None and args.rank is None:
+        parser.error("at least one of --qc/-q or --rank/-r is required.")
+
+    return args
 
 
 def main() -> None:
@@ -182,18 +232,27 @@ def main() -> None:
     args = parse_args()
     report = load_qc_report(args.qc_report)
 
-    emoji = QC_STATUS_TO_EMOJI[args.qc]
+    emoji = QC_STATUS_TO_EMOJI[args.qc] if args.qc is not None else None
 
     if args.label:
-        files = filter_label_files(report, emoji, full_path=args.full_path)
+        files = filter_label_files(
+            report, emoji, args.rank, full_path=args.full_path
+        )
     else:
-        files = filter_input_files(report, emoji, full_path=args.full_path)
+        files = filter_input_files(
+            report, emoji, args.rank, full_path=args.full_path
+        )
 
     for f in sorted(files):
         print(f)
 
-    # Print total count
-    print(f"Total files with QC '{args.qc}' ({emoji}): {len(files)}")
+    # Print total count, describing the active filters.
+    filters = []
+    if args.qc is not None:
+        filters.append(f"QC '{args.qc}' ({emoji})")
+    if args.rank is not None:
+        filters.append(f"rank {args.rank}")
+    print(f"Total files with {' and '.join(filters)}: {len(files)}")
 
 
 if __name__ == "__main__":

--- a/get_qc_input_files.py
+++ b/get_qc_input_files.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+Extract input filenames from SCT's qc_report.json for a given QC emoji.
+
+Usage:
+  python get_qc_input_files.py --qc "✅" qc_report.json
+  python get_qc_input_files.py --qc "⚠️" --full-path qc_report.json
+
+Example output:
+$ python ~/code/manual-correction/get_qc_input_files.py --qc ✅ qc_report.json
+    sub-001_T2w.nii.gz
+    sub-004_T2w.nii.gz
+"""
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+EMOJI_CHOICES: List[str] = ["✅", "⚠️", "❌"]
+
+
+def load_qc_report(path: Path) -> Dict[str, Any]:
+    """Load QC report JSON file.
+
+    Args:
+        path: Path to qc_report.json.
+
+    Returns:
+        Parsed JSON as a dictionary.
+
+    Raises:
+        FileNotFoundError: If the file does not exist.
+        json.JSONDecodeError: If the file is not valid JSON.
+    """
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def filter_input_files(
+    report: Dict[str, Any], emoji: str, full_path: bool = False
+) -> List[str]:
+    """Filter inputFile entries by QC emoji.
+
+    Args:
+        report: Parsed QC report dictionary.
+        emoji: QC emoji to filter by (e.g. "✅", "⚠️", "❌").
+        full_path: If True, return path/inputFile, otherwise only inputFile.
+
+    Returns:
+        List of inputFile strings (or full paths) matching the given emoji.
+    """
+    datasets = report.get("datasets", [])
+    results: List[str] = []
+
+    for item in datasets:
+        if item.get("qc") != emoji:
+            continue
+        input_file = item.get("inputFile")
+        if not input_file:
+            continue
+
+        if full_path:
+            base_path = item.get("path", "")
+            results.append(str(Path(base_path) / input_file))
+        else:
+            results.append(input_file)
+
+    return results
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Returns:
+        Parsed arguments namespace.
+    """
+    parser = argparse.ArgumentParser(
+        description="Get inputFiles for a given QC emoji from qc_report.json."
+    )
+    parser.add_argument(
+        "qc_report",
+        type=Path,
+        help="Path to qc_report.json.",
+    )
+    parser.add_argument(
+        "--qc",
+        "-q",
+        required=True,
+        choices=EMOJI_CHOICES,
+        help="QC emoji to filter by (✅, ⚠️, or ❌).",
+    )
+    parser.add_argument(
+        "--full-path",
+        action="store_true",
+        help="Print full paths (path/inputFile) instead of only inputFile.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Entry point for the script."""
+    args = parse_args()
+    report = load_qc_report(args.qc_report)
+    input_files = filter_input_files(report, args.qc, full_path=args.full_path)
+
+    for f in input_files:
+        print(f)
+
+    # Print total count
+    print(f"Total files with QC '{args.qc}': {len(input_files)}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/get_qc_input_files.py
+++ b/get_qc_input_files.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 """
-Extract file names from SCT's qc_report.json for a given QC emoji.
+Extract file names from SCT's qc_report.json for a given QC status.
+
+The QC status is passed as a keyword (``pass``, ``warn``, or ``fail``) rather
+than the raw emoji, which interacts awkwardly with some shells (e.g. zsh on
+macOS). The keyword is mapped internally to the emoji stored in the report.
 
 By default prints each matching entry's ``inputFile`` (the source image, e.g.
 the T2w). Pass ``--label`` to instead print the label file being QC'd, parsed
@@ -8,15 +12,15 @@ from the ``-s`` argument of the entry's ``cmdline``. This distinguishes sessions
 that have several QC entries (one per label: seg, canal, disc, pmj, ...).
 
 Usage:
-  python get_qc_input_files.py --qc "✅" qc_report.json
-  python get_qc_input_files.py --qc "✅" --label qc_report.json
-  python get_qc_input_files.py --qc "⚠️" --label --full-path qc_report.json
+  python get_qc_input_files.py --qc pass qc_report.json
+  python get_qc_input_files.py --qc pass --label qc_report.json
+  python get_qc_input_files.py --qc warn --label --full-path qc_report.json
 
 Example output:
-$ python ~/code/manual-correction/get_qc_input_files.py --qc ✅ qc_report.json
+$ python ~/code/manual-correction/get_qc_input_files.py --qc pass qc_report.json
     sub-001_T2w.nii.gz
     sub-004_T2w.nii.gz
-$ python ~/code/manual-correction/get_qc_input_files.py --qc ✅ --label qc_report.json
+$ python ~/code/manual-correction/get_qc_input_files.py --qc pass --label qc_report.json
     sub-001_T2w_seg.nii.gz
     sub-001_T2w_pmj.nii.gz
 """
@@ -28,7 +32,14 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 
-EMOJI_CHOICES: List[str] = ["✅", "⚠️", "❌"]
+# Maps the string keyword accepted on the command line to the emoji stored in
+# the QC report. Emojis are avoided as CLI arguments because they interact
+# awkwardly with some shells (e.g. zsh on macOS).
+QC_STATUS_TO_EMOJI: Dict[str, str] = {
+    "pass": "✅",
+    "warn": "⚠️",
+    "fail": "❌",
+}
 
 # Matches the label/segmentation passed to `-s` in an entry's cmdline.
 SEG_ARG_RE = re.compile(r"-s\s+(\S+\.nii\.gz)")
@@ -136,7 +147,7 @@ def parse_args() -> argparse.Namespace:
         Parsed arguments namespace.
     """
     parser = argparse.ArgumentParser(
-        description="Get files for a given QC emoji from qc_report.json."
+        description="Get files for a given QC status from qc_report.json."
     )
     parser.add_argument(
         "qc_report",
@@ -147,8 +158,8 @@ def parse_args() -> argparse.Namespace:
         "--qc",
         "-q",
         required=True,
-        choices=EMOJI_CHOICES,
-        help="QC emoji to filter by (✅, ⚠️, or ❌).",
+        choices=list(QC_STATUS_TO_EMOJI),
+        help="QC status to filter by: 'pass' (✅), 'warn' (⚠️), or 'fail' (❌).",
     )
     parser.add_argument(
         "--label",
@@ -171,16 +182,18 @@ def main() -> None:
     args = parse_args()
     report = load_qc_report(args.qc_report)
 
+    emoji = QC_STATUS_TO_EMOJI[args.qc]
+
     if args.label:
-        files = filter_label_files(report, args.qc, full_path=args.full_path)
+        files = filter_label_files(report, emoji, full_path=args.full_path)
     else:
-        files = filter_input_files(report, args.qc, full_path=args.full_path)
+        files = filter_input_files(report, emoji, full_path=args.full_path)
 
     for f in sorted(files):
         print(f)
 
     # Print total count
-    print(f"Total files with QC '{args.qc}': {len(files)}")
+    print(f"Total files with QC '{args.qc}' ({emoji}): {len(files)}")
 
 
 if __name__ == "__main__":

--- a/tests/test_get_qc_input_files.py
+++ b/tests/test_get_qc_input_files.py
@@ -1,0 +1,337 @@
+#######################################################################
+#
+# Tests for get_qc_input_files.py
+#
+# RUN BY:
+#   python -m pytest -v tests/test_get_qc_input_files.py
+#######################################################################
+
+import os
+import sys
+import json
+import subprocess
+from pathlib import Path
+
+from get_qc_input_files import (
+    filter_input_files,
+    filter_label_files,
+    entry_matches,
+    load_qc_report,
+    extract_label_file,
+    QC_STATUS_TO_EMOJI,
+)
+
+# Path to the script under test, resolved relative to this test file so it works
+# regardless of the current working directory.
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / "get_qc_input_files.py"
+REPO_ROOT = SCRIPT_PATH.parent
+
+
+def sample_report():
+    """Return a small in-memory QC report exercising the various filters.
+
+    Entries cover: pass/warn/fail QC statuses, unset ("") QC, ranks 0/2/5,
+    rank=None, an entry with no inputFile, and cmdlines with and without a
+    ``-s`` label argument.
+    """
+    return {
+        "datasets": [
+            {  # 0: pass, rank 2
+                "qc": "✅",
+                "rank": 2,
+                "inputFile": "sub-001_T2w.nii.gz",
+                "path": "sub-001",
+                "cmdline": "sct_qc -p sct_deepseg_sc -i sub-001/anat/sub-001_T2w.nii.gz "
+                           "-s sub-001/anat/sub-001_T2w_seg.nii.gz",
+            },
+            {  # 1: unset qc, rank 2
+                "qc": "",
+                "rank": 2,
+                "inputFile": "sub-002_T2w.nii.gz",
+                "path": "sub-002",
+                "cmdline": "sct_qc -p sct_deepseg_sc -i sub-002/anat/sub-002_T2w.nii.gz "
+                           "-s sub-002/anat/sub-002_T2w_seg.nii.gz",
+            },
+            {  # 2: unset qc, rank 0
+                "qc": "",
+                "rank": 0,
+                "inputFile": "sub-003_T2w.nii.gz",
+                "path": "sub-003",
+                "cmdline": "sct_qc -p sct_deepseg_sc -i sub-003/anat/sub-003_T2w.nii.gz "
+                           "-s sub-003/anat/sub-003_T2w_seg.nii.gz",
+            },
+            {  # 3: warn, rank None
+                "qc": "⚠️",
+                "rank": None,
+                "inputFile": "sub-004_T2w.nii.gz",
+                "path": "sub-004",
+                "cmdline": "sct_qc -p sct_deepseg_sc -i sub-004/anat/sub-004_T2w.nii.gz "
+                           "-s sub-004/anat/sub-004_T2w_seg.nii.gz",
+            },
+            {  # 4: pass, rank 5, NO inputFile, has -s label
+                "qc": "✅",
+                "rank": 5,
+                "path": "sub-005",
+                "cmdline": "sct_qc -p sct_get_centerline -i sub-005/anat/sub-005_T2w.nii.gz "
+                           "-s sub-005/anat/sub-005_T2w_pmj.nii.gz",
+            },
+            {  # 5: fail, rank None, cmdline with NO -s label
+                "qc": "❌",
+                "rank": None,
+                "inputFile": "sub-006_T2w.nii.gz",
+                "path": "sub-006",
+                "cmdline": "sct_qc -p some_process -i sub-006/anat/sub-006_T2w.nii.gz",
+            },
+        ]
+    }
+
+
+def write_report(tmp_path):
+    """Write the sample report to a JSON file and return its Path."""
+    report_path = tmp_path / "qc_report.json"
+    with report_path.open("w", encoding="utf-8") as f:
+        json.dump(sample_report(), f)
+    return report_path
+
+
+# ---------------------------------------------------------------------------
+# --qc filtering (filter_input_files with a QC emoji, rank=None)
+# ---------------------------------------------------------------------------
+
+def test_filter_input_files_qc_pass():
+    """--qc pass returns only the ✅ entries' inputFiles (skipping ones w/o inputFile)."""
+    report = sample_report()
+    result = filter_input_files(report, QC_STATUS_TO_EMOJI["pass"], None)
+    # Entry 0 is ✅ with an inputFile; entry 4 is ✅ but has no inputFile (skipped).
+    assert result == ["sub-001_T2w.nii.gz"]
+
+
+def test_filter_input_files_qc_warn():
+    """--qc warn returns the single ⚠️ entry's inputFile."""
+    report = sample_report()
+    result = filter_input_files(report, QC_STATUS_TO_EMOJI["warn"], None)
+    assert result == ["sub-004_T2w.nii.gz"]
+
+
+def test_filter_input_files_qc_fail():
+    """--qc fail returns the single ❌ entry's inputFile."""
+    report = sample_report()
+    result = filter_input_files(report, QC_STATUS_TO_EMOJI["fail"], None)
+    assert result == ["sub-006_T2w.nii.gz"]
+
+
+def test_filter_input_files_qc_full_path():
+    """full_path=True joins path/inputFile."""
+    report = sample_report()
+    result = filter_input_files(report, QC_STATUS_TO_EMOJI["pass"], None, full_path=True)
+    assert result == ["sub-001/sub-001_T2w.nii.gz"]
+
+
+# ---------------------------------------------------------------------------
+# --rank filtering (filter_input_files with emoji=None)
+# ---------------------------------------------------------------------------
+
+def test_filter_input_files_rank_matches_regardless_of_qc():
+    """--rank 2 returns all entries with rank 2 regardless of their QC status."""
+    report = sample_report()
+    result = filter_input_files(report, None, 2)
+    # Entry 0 (✅) and entry 1 ("") both have rank 2.
+    assert result == ["sub-001_T2w.nii.gz", "sub-002_T2w.nii.gz"]
+
+
+def test_filter_input_files_rank_zero():
+    """--rank 0 returns its single entry (0 must not be treated as 'no filter')."""
+    report = sample_report()
+    result = filter_input_files(report, None, 0)
+    assert result == ["sub-003_T2w.nii.gz"]
+
+
+def test_filter_input_files_rank_not_present_returns_empty():
+    """A rank present on no entry returns an empty list."""
+    report = sample_report()
+    result = filter_input_files(report, None, 9)
+    assert result == []
+
+
+def test_entry_matches_none_none_always_true():
+    """entry_matches(item, None, None) is always True (the 'no filter' path)."""
+    assert entry_matches({"qc": "✅", "rank": 2}, None, None) is True
+    assert entry_matches({"qc": "", "rank": None}, None, None) is True
+    assert entry_matches({}, None, None) is True
+
+
+# ---------------------------------------------------------------------------
+# Combined --qc + --rank (AND semantics)
+# ---------------------------------------------------------------------------
+
+def test_filter_input_files_qc_and_rank_match():
+    """Combined filter returns only entries matching BOTH qc and rank."""
+    report = sample_report()
+    result = filter_input_files(report, QC_STATUS_TO_EMOJI["pass"], 2)
+    # Entry 0 is ✅ AND rank 2. Entry 1 is rank 2 but not ✅; entry 4 is ✅ but rank 5.
+    assert result == ["sub-001_T2w.nii.gz"]
+
+
+def test_filter_input_files_qc_and_rank_no_match():
+    """Combined filter returns [] when no entry matches both."""
+    report = sample_report()
+    result = filter_input_files(report, QC_STATUS_TO_EMOJI["pass"], 0)
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# entry_matches truth table
+# ---------------------------------------------------------------------------
+
+def test_entry_matches_truth_table():
+    """entry_matches AND-combines the provided (non-None) filters."""
+    item = {"qc": "✅", "rank": 2}
+    # (None, None) -> True
+    assert entry_matches(item, None, None) is True
+    # matching emoji only
+    assert entry_matches(item, "✅", None) is True
+    # non-matching emoji
+    assert entry_matches(item, "⚠️", None) is False
+    # matching rank only
+    assert entry_matches(item, None, 2) is True
+    # non-matching rank
+    assert entry_matches(item, None, 3) is False
+    # both match
+    assert entry_matches(item, "✅", 2) is True
+    # one matches, one doesn't
+    assert entry_matches(item, "✅", 3) is False
+    assert entry_matches(item, "⚠️", 2) is False
+
+
+# ---------------------------------------------------------------------------
+# filter_label_files
+# ---------------------------------------------------------------------------
+
+def test_filter_label_files_basename_default():
+    """filter_label_files returns the -s file basename by default."""
+    report = sample_report()
+    result = filter_label_files(report, QC_STATUS_TO_EMOJI["pass"], None)
+    # Both ✅ entries (0 and 4) have a -s label, even though entry 4 has no inputFile.
+    assert result == ["sub-001_T2w_seg.nii.gz", "sub-005_T2w_pmj.nii.gz"]
+
+
+def test_filter_label_files_full_path():
+    """filter_label_files returns the full -s path when full_path=True."""
+    report = sample_report()
+    result = filter_label_files(report, QC_STATUS_TO_EMOJI["pass"], None, full_path=True)
+    assert result == [
+        "sub-001/anat/sub-001_T2w_seg.nii.gz",
+        "sub-005/anat/sub-005_T2w_pmj.nii.gz",
+    ]
+
+
+def test_filter_label_files_skips_entries_without_s_arg():
+    """Entries whose cmdline has no -s ... .nii.gz are skipped."""
+    report = sample_report()
+    # Entry 5 (❌) has a cmdline without -s, so nothing is returned.
+    result = filter_label_files(report, QC_STATUS_TO_EMOJI["fail"], None)
+    assert result == []
+
+
+def test_filter_label_files_respects_rank_filter():
+    """filter_label_files honours the rank filter."""
+    report = sample_report()
+    result = filter_label_files(report, None, 2)
+    assert result == ["sub-001_T2w_seg.nii.gz", "sub-002_T2w_seg.nii.gz"]
+
+
+# ---------------------------------------------------------------------------
+# extract_label_file
+# ---------------------------------------------------------------------------
+
+def test_extract_label_file_normal():
+    """extract_label_file pulls the -s path out of a normal cmdline."""
+    cmdline = "sct_qc -p sct_deepseg_sc -i img.nii.gz -s sub-001/anat/sub-001_T2w_seg.nii.gz"
+    assert extract_label_file(cmdline) == "sub-001/anat/sub-001_T2w_seg.nii.gz"
+
+
+def test_extract_label_file_no_s_arg():
+    """extract_label_file returns None when there is no -s argument."""
+    assert extract_label_file("sct_qc -p some_process -i sub-006_T2w.nii.gz") is None
+
+
+def test_extract_label_file_empty_and_none():
+    """extract_label_file returns None for empty string and None input."""
+    assert extract_label_file("") is None
+    assert extract_label_file(None) is None
+
+
+# ---------------------------------------------------------------------------
+# load_qc_report
+# ---------------------------------------------------------------------------
+
+def test_load_qc_report_roundtrip(tmp_path):
+    """load_qc_report reads a JSON file back to an equal dict."""
+    report = sample_report()
+    report_path = tmp_path / "qc_report.json"
+    with report_path.open("w", encoding="utf-8") as f:
+        json.dump(report, f)
+
+    loaded = load_qc_report(report_path)
+    assert loaded == report
+
+
+# ---------------------------------------------------------------------------
+# CLI-level behavior (subprocess)
+# ---------------------------------------------------------------------------
+
+def run_cli(*args):
+    """Run the script as a subprocess and return the CompletedProcess."""
+    env = {**os.environ, "PYTHONIOENCODING": "utf-8"}
+    return subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), *args],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        cwd=str(REPO_ROOT),
+        env=env,
+    )
+
+
+def test_cli_qc_pass(tmp_path):
+    """--qc pass exits 0, prints the inputFile and the pass summary line."""
+    report_path = write_report(tmp_path)
+    result = run_cli("--qc", "pass", str(report_path))
+    assert result.returncode == 0, result.stderr
+    assert "sub-001_T2w.nii.gz" in result.stdout
+    assert f"Total files with QC 'pass' ({QC_STATUS_TO_EMOJI['pass']}): 1" in result.stdout
+
+
+def test_cli_rank(tmp_path):
+    """--rank 2 exits 0 and reports the rank summary line."""
+    report_path = write_report(tmp_path)
+    result = run_cli("--rank", "2", str(report_path))
+    assert result.returncode == 0, result.stderr
+    assert "sub-001_T2w.nii.gz" in result.stdout
+    assert "sub-002_T2w.nii.gz" in result.stdout
+    assert "Total files with rank 2: 2" in result.stdout
+
+
+def test_cli_qc_and_rank(tmp_path):
+    """--qc pass --rank 2 exits 0 and reports the combined summary line."""
+    report_path = write_report(tmp_path)
+    result = run_cli("--qc", "pass", "--rank", "2", str(report_path))
+    assert result.returncode == 0, result.stderr
+    expected = f"Total files with QC 'pass' ({QC_STATUS_TO_EMOJI['pass']}) and rank 2: 1"
+    assert expected in result.stdout
+
+
+def test_cli_requires_qc_or_rank(tmp_path):
+    """Passing neither --qc nor --rank is an argparse error (exit code 2)."""
+    report_path = write_report(tmp_path)
+    result = run_cli(str(report_path))
+    assert result.returncode == 2
+    assert "at least one of --qc" in result.stderr
+
+
+def test_cli_rank_out_of_range(tmp_path):
+    """An out-of-range --rank is an invalid choice (exit code 2)."""
+    report_path = write_report(tmp_path)
+    result = run_cli("--rank", "10", str(report_path))
+    assert result.returncode == 2
+    assert "invalid choice" in result.stderr


### PR DESCRIPTION
## Summary

Adds `get_qc_input_files.py`, a small utility script that extracts `inputFile` entries from SCT's `qc_report.json` filtered by QC status (`pass` / `warn` / `fail`).

This is useful for splitting subjects into "passing" vs. "needs manual correction" lists after a QC review, e.g. to copy `pass` files to `derivatives/labels/` or to build a `config_correction.yml` from `warn` subjects.

## Usage

- `--qc` takes a string keyword (`pass` / `warn` / `fail`) 
- `--rank`/`-r` option filters by the entry's `rank` (0–9, set with the number keys in the QC report viewer). 

```bash
# Print filenames with QC = pass (✅)
python get_qc_input_files.py --qc pass qc_report.json

# Print full paths (path/inputFile) for QC = warn (⚠️)
python get_qc_input_files.py --qc warn --full-path qc_report.json

# Filter by rank (0–9)
python get_qc_input_files.py --rank 2 qc_report.json

# Combine: passing AND rank 2
python get_qc_input_files.py --qc pass --rank 2 qc_report.json
```

Example output:

```
$ python get_qc_input_files.py --qc pass qc_report.json
sub-001_T2w.nii.gz
sub-004_T2w.nii.gz
Total files with QC 'pass' (✅): 2
```

Output is sorted alphabetically; a total count is printed at the end.

'--label`/`-l` prints the label file instead of the source input file. This distinguishes per-label entries when one image has several QC labels (e.g. cord passed, canal failed).

```
$ python get_qc_input_files.py --qc pass --label qc_report.json
sub-001_T2w_seg.nii.gz
sub-001_T2w_pmj.nii.gz
```
