### PR TITLE
Add func (fMRI) support to fetch_subject_and_session()

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -72,6 +72,22 @@ def test_fetch_subject_and_session():
     assert filename == "invalid_filename_path.nii.gz"
     assert contrast == "anat"
 
+    # Test 8: Test for correct contrast detection of func (fMRI) data from folder path
+    filename_path = "/home/user/MRI/bids/sub-004/func/sub-004_task-rest_bold.nii.gz"
+    subjectID, sessionID, filename, contrast = fetch_subject_and_session(filename_path)
+    assert subjectID == "sub-004"
+    assert sessionID == ""
+    assert filename == "sub-004_task-rest_bold.nii.gz"
+    assert contrast == "func"
+
+    # Test 9: Test for correct contrast detection of func (fMRI) data from filename only (no folder path)
+    filename_path = "sub-004_task-rest_bold.nii.gz"
+    subjectID, sessionID, filename, contrast = fetch_subject_and_session(filename_path)
+    assert subjectID == "sub-004"
+    assert sessionID == ""
+    assert filename == "sub-004_task-rest_bold.nii.gz"
+    assert contrast == "func"
+
 
 def test_splitext():
     assert splitext('sub-001_ses-01_T1w.nii') == ('sub-001_ses-01_T1w', '.nii')

--- a/utils.py
+++ b/utils.py
@@ -42,8 +42,13 @@ def fetch_subject_and_session(filename_path):
     # . - match any character (except newline)
     # *? - match the previous element as few times as possible (zero or more times)
 
-    # TODO - add support for func (fMRI)
-    contrast = 'dwi' if 'dwi' in filename_path else 'anat'  # Return contrast (dwi or anat)
+    # Return contrast (dwi, func or anat)
+    if 'dwi' in filename_path:
+        contrast = 'dwi'
+    elif 'func' in filename_path or '_bold' in filename_path:
+        contrast = 'func'
+    else:
+        contrast = 'anat'
 
     return subjectID, sessionID, filename, contrast
 


### PR DESCRIPTION
## Summary
- Fixes #125
- `fetch_subject_and_session()` in `utils.py` hardcoded `contrast` to either `'dwi'` or `'anat'`, so any file under BIDS `func/` (e.g. fMRI bold data) was incorrectly assumed to live under `anat/`. This caused the tool to report files as missing even though they existed, just under `func/`.
- Now detects `func` from either `/func/` in the path or `_bold` in the filename (so it also works when only a bare filename is passed, consistent with how `dwi` is detected).

## Test plan
- [x] Added two new cases to `test_fetch_subject_and_session` (full path with `func/` folder, and bare filename with `_bold` suffix) — both pass.
- [x] Ran full test suite (`pytest tests/`): 22 passed, no regressions.

## Related issues

Solves: https://github.com/spinalcordtoolbox/manual-correction/issues/81, https://github.com/spinalcordtoolbox/manual-correction/issues/125
Previous [PR](https://github.com/spinalcordtoolbox/manual-correction/pull/88) which was reverted in https://github.com/spinalcordtoolbox/manual-correction/commit/f19a6a0372972d5ad6b939033d7044250d970800. (don't remember details why)