### PR TITLE
Fix incorrect image count when using wildcard in config file

### DIFF
--- a/manual_correction.py
+++ b/manual_correction.py
@@ -797,9 +797,15 @@ def main():
         args.path_out)
 
     # Print parsed arguments
-    # Count total number of images to process across all tasks
-    total_files = sum(len(files) for task, files in dict_yml.items()
-                      if task.startswith('FILES') and isinstance(files, list))
+    # Count total number of images to process across all tasks, expanding wildcard patterns (e.g., 'sub-*_T2w.nii.gz')
+    # to the actual number of matching files
+    total_files = 0
+    for task, files in dict_yml.items():
+        if task.startswith('FILES') and isinstance(files, list) and files:
+            if '*' in files[0] and len(files) == 1:
+                total_files += len(utils.expand_wildcard_files(files, task, dict_yml, path_img))
+            else:
+                total_files += len(files)
 
     logging.info("-" * 100)
     logging.info("Parsing of arguments:")
@@ -868,23 +874,7 @@ def main():
             if len(files) > 0:
                 # Handle regex (i.e., iterate over all subjects)
                 if '*' in files[0] and len(files) == 1:
-                    subject, ses, filename, contrast = utils.fetch_subject_and_session(files[0])
-                    # Get list of files recursively
-                    glob_files = sorted(glob.glob(os.path.join(path_img, '**', filename),
-                                            recursive=True))
-                    # Skip filenames containing "notused"
-                    glob_files = [file for file in glob_files if 'notused' not in file]
-                    # Get list of already corrected files
-                    if task.replace('FILES', 'CORR') in dict_yml.keys():
-                        corr_files = dict_yml[task.replace('FILES', 'CORR')]
-                    else:
-                        corr_files = []
-                    #  Remove labels under derivatives and already corrected files
-                    files = []
-                    for file in glob_files:
-                        subject, ses, filename, contrast = utils.fetch_subject_and_session(file)
-                        if ('derivatives' not in file) and (filename not in corr_files):
-                            files.append(file)
+                    files = utils.expand_wildcard_files(files, task, dict_yml, path_img)
                 # Loop across files
                 for file in tqdm.tqdm(files, desc="{}".format(task), unit="file"):
                     # Print empty line to not overlay with tqdm progress bar

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,7 +12,8 @@ import numpy as np
 import nibabel as nib
 
 from utils import fetch_subject_and_session, add_suffix, remove_suffix, splitext, curate_dict_yml, get_full_path, \
-    check_files_exist, fetch_yaml_config, track_corrections, get_orientation, change_orientation
+    check_files_exist, fetch_yaml_config, track_corrections, get_orientation, change_orientation, \
+    expand_wildcard_files
 
 
 def test_fetch_subject_and_session():
@@ -115,6 +116,31 @@ def test_curate_dict_yml():
                                             'sub-002_acq-sag_T2w.nii.gz',
                                             'sub-003_acq-sag_T2w.nii.gz']}
     assert curate_dict_yml(input_dict) == expected_output_dict
+
+
+def test_expand_wildcard_files(tmp_path):
+    """
+    Test that expand_wildcard_files resolves a wildcard pattern (e.g., 'sub-*_T2w.nii.gz') to the actual list of
+    matching files, excluding files under 'derivatives' and files already tracked as corrected (CORR_* key).
+    Context: the "Number of images to correct" printout was wrong when a wildcard was used because the count was
+    computed on the raw (unexpanded) 1-item wildcard list instead of the resolved file list.
+    """
+    path_img = tmp_path
+    for sub in ['sub-001', 'sub-002', 'sub-003']:
+        (path_img / sub / 'anat').mkdir(parents=True)
+        (path_img / sub / 'anat' / f'{sub}_T2w.nii.gz').touch()
+    # File under derivatives should be excluded
+    (path_img / 'derivatives' / 'labels' / 'sub-001' / 'anat').mkdir(parents=True)
+    (path_img / 'derivatives' / 'labels' / 'sub-001' / 'anat' / 'sub-001_T2w.nii.gz').touch()
+
+    dict_yml = {'FILES_LESION': ['sub-*_T2w.nii.gz']}
+    resolved_files = expand_wildcard_files(dict_yml['FILES_LESION'], 'FILES_LESION', dict_yml, str(path_img))
+    assert len(resolved_files) == 3
+
+    # Already corrected files (tracked under CORR_LESION) should be excluded
+    dict_yml['CORR_LESION'] = ['sub-002_T2w.nii.gz']
+    resolved_files = expand_wildcard_files(dict_yml['FILES_LESION'], 'FILES_LESION', dict_yml, str(path_img))
+    assert len(resolved_files) == 2
 
 
 def test_get_full_path(tmp_path):

--- a/utils.py
+++ b/utils.py
@@ -8,6 +8,7 @@
 
 import os
 import re
+import glob
 import logging
 import sys
 import textwrap
@@ -192,6 +193,32 @@ def curate_dict_yml(dict_yml):
     for task, files in dict_yml.items():
         dict_yml_curate[task] = [os.path.basename(file) for file in files]
     return dict_yml_curate
+
+
+def expand_wildcard_files(files, task, dict_yml, path_img):
+    """
+    Expand a wildcard file pattern (e.g., 'sub-*_T2w.nii.gz') into the actual list of matching files found
+    under path_img, excluding files under 'derivatives' and files already tracked as corrected (CORR_* key).
+    :param files: list containing a single wildcard pattern, e.g., ['sub-*_T2w.nii.gz']
+    :param task: task name, e.g., 'FILES_SEG'
+    :param dict_yml: dict with the full YAML config (used to look up already corrected files under CORR_*)
+    :param path_img: full path to the folder with images
+    :return: list of absolute paths to the files matching the wildcard pattern
+    """
+    _, _, filename, _ = fetch_subject_and_session(files[0])
+    # Get list of files recursively
+    glob_files = sorted(glob.glob(os.path.join(path_img, '**', filename), recursive=True))
+    # Skip filenames containing "notused"
+    glob_files = [file for file in glob_files if 'notused' not in file]
+    # Get list of already corrected files
+    corr_files = dict_yml.get(task.replace('FILES', 'CORR'), [])
+    # Remove labels under derivatives and already corrected files
+    resolved_files = []
+    for file in glob_files:
+        _, _, filename, _ = fetch_subject_and_session(file)
+        if 'derivatives' not in file and filename not in corr_files:
+            resolved_files.append(file)
+    return resolved_files
 
 
 def get_full_path(path):


### PR DESCRIPTION
## Summary
- The "Number of images to correct" printout counted the raw YAML list length (1 for a wildcard entry like `sub-*_T2w.nii.gz`) instead of the actual number of matching files, since wildcard expansion happened later in the script.
- Extracted the glob expansion logic into `utils.expand_wildcard_files()` and reused it both for the count and the main processing loop (removing the previous duplication).